### PR TITLE
feat: add WithContext client funcs for each flag resolution and made EvaluationOptions variadic to simplify basic API usage

### DIFF
--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -112,10 +112,25 @@ type EvaluationDetails struct {
 	InterfaceResolutionDetail
 }
 
-// BooleanValue return boolean evaluation for flag
-func (c Client) BooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options EvaluationOptions) (bool, error) {
+// BooleanValue returns boolean evaluation for flag.
+// If options are provided, only first given is used.
+func (c Client) BooleanValue(flag string, defaultValue bool, options ...EvaluationOptions) (bool, error) {
+	return c.booleanValue(flag, defaultValue, EvaluationContext{}, options...)
+}
 
-	evalDetails, err := c.evaluate(flag, Boolean, defaultValue, evalCtx, options)
+// BooleanValueWithContext returns boolean evaluation for flag with context.
+// If options are provided, only first given is used.
+func (c Client) BooleanValueWithContext(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOptions) (bool, error) {
+	return c.booleanValue(flag, defaultValue, evalCtx, options...)
+}
+
+func (c Client) booleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOptions) (bool, error) {
+	optns := EvaluationOptions{}
+	if len(options) > 0 {
+		optns = options[0]
+	}
+
+	evalDetails, err := c.evaluate(flag, Boolean, defaultValue, evalCtx, optns)
 	if err != nil {
 		return defaultValue, err
 	}
@@ -133,9 +148,25 @@ func (c Client) BooleanValue(flag string, defaultValue bool, evalCtx EvaluationC
 	return value, nil
 }
 
-// StringValue return string evaluation for flag
-func (c Client) StringValue(flag string, defaultValue string, evalCtx EvaluationContext, options EvaluationOptions) (string, error) {
-	evalDetails, err := c.evaluate(flag, String, defaultValue, evalCtx, options)
+// StringValue returns string evaluation for flag.
+// If options are provided, only first given is used.
+func (c Client) StringValue(flag string, defaultValue string, options ...EvaluationOptions) (string, error) {
+	return c.stringValue(flag, defaultValue, EvaluationContext{}, options...)
+}
+
+// StringValueWithContext returns string evaluation for flag with context.
+// If options are provided, only first given is used.
+func (c Client) StringValueWithContext(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOptions) (string, error) {
+	return c.stringValue(flag, defaultValue, evalCtx, options...)
+}
+
+func (c Client) stringValue(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOptions) (string, error) {
+	optns := EvaluationOptions{}
+	if len(options) > 0 {
+		optns = options[0]
+	}
+
+	evalDetails, err := c.evaluate(flag, String, defaultValue, evalCtx, optns)
 	if err != nil {
 		return defaultValue, err
 	}
@@ -153,9 +184,25 @@ func (c Client) StringValue(flag string, defaultValue string, evalCtx Evaluation
 	return value, nil
 }
 
-// FloatValue return float evaluation for flag
-func (c Client) FloatValue(flag string, defaultValue float64, evalCtx EvaluationContext, options EvaluationOptions) (float64, error) {
-	evalDetails, err := c.evaluate(flag, Float, defaultValue, evalCtx, options)
+// FloatValue returns float evaluation for flag.
+// If options are provided, only first given is used.
+func (c Client) FloatValue(flag string, defaultValue float64, options ...EvaluationOptions) (float64, error) {
+	return c.floatValue(flag, defaultValue, EvaluationContext{}, options...)
+}
+
+// FloatValueWithContext returns float evaluation for flag with context.
+// If options are provided, only first given is used.
+func (c Client) FloatValueWithContext(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOptions) (float64, error) {
+	return c.floatValue(flag, defaultValue, evalCtx, options...)
+}
+
+func (c Client) floatValue(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOptions) (float64, error) {
+	optns := EvaluationOptions{}
+	if len(options) > 0 {
+		optns = options[0]
+	}
+
+	evalDetails, err := c.evaluate(flag, Float, defaultValue, evalCtx, optns)
 	if err != nil {
 		return defaultValue, err
 	}
@@ -173,9 +220,25 @@ func (c Client) FloatValue(flag string, defaultValue float64, evalCtx Evaluation
 	return value, nil
 }
 
-// IntValue return int evaluation for flag
-func (c Client) IntValue(flag string, defaultValue int64, evalCtx EvaluationContext, options EvaluationOptions) (int64, error) {
-	evalDetails, err := c.evaluate(flag, Int, defaultValue, evalCtx, options)
+// IntValue returns int evaluation for flag.
+// If options are provided, only first given is used.
+func (c Client) IntValue(flag string, defaultValue int64, options ...EvaluationOptions) (int64, error) {
+	return c.intValue(flag, defaultValue, EvaluationContext{}, options...)
+}
+
+// IntValueWithContext returns int evaluation for flag with context.
+// If options are provided, only first given is used.
+func (c Client) IntValueWithContext(flag string, defaultValue int64, evalCtx EvaluationContext, options ...EvaluationOptions) (int64, error) {
+	return c.intValue(flag, defaultValue, evalCtx, options...)
+}
+
+func (c Client) intValue(flag string, defaultValue int64, evalCtx EvaluationContext, options ...EvaluationOptions) (int64, error) {
+	optns := EvaluationOptions{}
+	if len(options) > 0 {
+		optns = options[0]
+	}
+
+	evalDetails, err := c.evaluate(flag, Int, defaultValue, evalCtx, optns)
 	if err != nil {
 		return defaultValue, err
 	}
@@ -193,9 +256,25 @@ func (c Client) IntValue(flag string, defaultValue int64, evalCtx EvaluationCont
 	return value, nil
 }
 
-// ObjectValue return object evaluation for flag
-func (c Client) ObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options EvaluationOptions) (interface{}, error) {
-	evalDetails, err := c.evaluate(flag, Object, defaultValue, evalCtx, options)
+// ObjectValue returns object evaluation for flag.
+// If options are provided, only first given is used.
+func (c Client) ObjectValue(flag string, defaultValue interface{}, options ...EvaluationOptions) (interface{}, error) {
+	return c.objectValue(flag, defaultValue, EvaluationContext{}, options...)
+}
+
+// ObjectValueWithContext returns object evaluation for flag with context.
+// If options are provided, only first given is used.
+func (c Client) ObjectValueWithContext(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOptions) (interface{}, error) {
+	return c.objectValue(flag, defaultValue, evalCtx, options...)
+}
+
+func (c Client) objectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOptions) (interface{}, error) {
+	optns := EvaluationOptions{}
+	if len(options) > 0 {
+		optns = options[0]
+	}
+
+	evalDetails, err := c.evaluate(flag, Object, defaultValue, evalCtx, optns)
 	return evalDetails.Value, err
 }
 

--- a/pkg/openfeature/client_example_test.go
+++ b/pkg/openfeature/client_example_test.go
@@ -16,9 +16,7 @@ func ExampleNewClient() {
 
 func ExampleClient_BooleanValue() {
 	client := openfeature.NewClient("example-client")
-	value, err := client.BooleanValue(
-		"test-flag", true, openfeature.EvaluationContext{}, openfeature.EvaluationOptions{},
-	)
+	value, err := client.BooleanValue("test-flag", true)
 	if err != nil {
 		log.Fatal("error while getting boolean value : ", err)
 	}
@@ -29,9 +27,7 @@ func ExampleClient_BooleanValue() {
 
 func ExampleClient_StringValue() {
 	client := openfeature.NewClient("example-client")
-	value, err := client.StringValue(
-		"test-flag", "openfeature", openfeature.EvaluationContext{}, openfeature.EvaluationOptions{},
-	)
+	value, err := client.StringValue("test-flag", "openfeature")
 	if err != nil {
 		log.Fatal("error while getting string value : ", err)
 	}
@@ -42,9 +38,7 @@ func ExampleClient_StringValue() {
 
 func ExampleClient_FloatValue() {
 	client := openfeature.NewClient("example-client")
-	value, err := client.FloatValue(
-		"test-flag", 0.55, openfeature.EvaluationContext{}, openfeature.EvaluationOptions{},
-	)
+	value, err := client.FloatValue("test-flag", 0.55)
 	if err != nil {
 		log.Fatalf("error while getting float value: %v", err)
 	}
@@ -55,9 +49,7 @@ func ExampleClient_FloatValue() {
 
 func ExampleClient_IntValue() {
 	client := openfeature.NewClient("example-client")
-	value, err := client.IntValue(
-		"test-flag", 3, openfeature.EvaluationContext{}, openfeature.EvaluationOptions{},
-	)
+	value, err := client.IntValue("test-flag", 3)
 	if err != nil {
 		log.Fatalf("error while getting int value: %v", err)
 	}
@@ -68,9 +60,7 @@ func ExampleClient_IntValue() {
 
 func ExampleClient_ObjectValue() {
 	client := openfeature.NewClient("example-client")
-	value, err := client.ObjectValue(
-		"test-flag", map[string]string{"foo": "bar"}, openfeature.EvaluationContext{}, openfeature.EvaluationOptions{},
-	)
+	value, err := client.ObjectValue("test-flag", map[string]string{"foo": "bar"})
 	if err != nil {
 		log.Fatal("error while getting object value : ", err)
 	}

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -58,11 +58,16 @@ func TestRequirements_1_3(t *testing.T) {
 	client := NewClient("test-client")
 
 	type requirements interface {
-		BooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options EvaluationOptions) (bool, error)
-		StringValue(flag string, defaultValue string, evalCtx EvaluationContext, options EvaluationOptions) (string, error)
-		FloatValue(flag string, defaultValue float64, evalCtx EvaluationContext, options EvaluationOptions) (float64, error)
-		IntValue(flag string, defaultValue int64, evalCtx EvaluationContext, options EvaluationOptions) (int64, error)
-		ObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options EvaluationOptions) (interface{}, error)
+		BooleanValue(flag string, defaultValue bool, options ...EvaluationOptions) (bool, error)
+		StringValue(flag string, defaultValue string, options ...EvaluationOptions) (string, error)
+		FloatValue(flag string, defaultValue float64, options ...EvaluationOptions) (float64, error)
+		IntValue(flag string, defaultValue int64, options ...EvaluationOptions) (int64, error)
+		ObjectValue(flag string, defaultValue interface{}, options ...EvaluationOptions) (interface{}, error)
+		BooleanValueWithContext(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOptions) (bool, error)
+		StringValueWithContext(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOptions) (string, error)
+		FloatValueWithContext(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOptions) (float64, error)
+		IntValueWithContext(flag string, defaultValue int64, evalCtx EvaluationContext, options ...EvaluationOptions) (int64, error)
+		ObjectValueWithContext(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOptions) (interface{}, error)
 	}
 
 	var clientI interface{} = client
@@ -230,7 +235,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 			}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.BooleanValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
+		value, err := client.booleanValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
 		if err == nil {
 			t.Error("expected BooleanValue to return an error, got nil")
 		}
@@ -265,7 +270,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 			}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.StringValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
+		value, err := client.stringValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
 		if err == nil {
 			t.Error("expected StringValue to return an error, got nil")
 		}
@@ -300,7 +305,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 			}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.FloatValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
+		value, err := client.floatValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
 		if err == nil {
 			t.Error("expected FloatValue to return an error, got nil")
 		}
@@ -335,7 +340,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 			}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.IntValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
+		value, err := client.intValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
 		if err == nil {
 			t.Error("expected IntValue to return an error, got nil")
 		}
@@ -372,7 +377,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 			}).Times(2)
 		SetProvider(mockProvider)
 
-		value, err := client.ObjectValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
+		value, err := client.objectValue(flagKey, defaultValue, evalCtx, EvaluationOptions{})
 		if err == nil {
 			t.Error("expected ObjectValue to return an error, got nil")
 		}
@@ -505,7 +510,7 @@ func TestBeforeHookNilContext(t *testing.T) {
 	evalCtx := EvaluationContext{Attributes: attributes}
 	mockProvider.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), attributes)
 
-	_, err := client.BooleanValue(
+	_, err := client.booleanValue(
 		"foo", false, evalCtx, NewEvaluationOptions([]Hook{hookNilContext}, HookHints{}),
 	)
 	if err != nil {

--- a/pkg/openfeature/evaluation_context_test.go
+++ b/pkg/openfeature/evaluation_context_test.go
@@ -63,11 +63,11 @@ func TestRequirement_3_2_1(t *testing.T) {
 		client := NewClient("test")
 
 		type requirement interface {
-			BooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options EvaluationOptions) (bool, error)
-			StringValue(flag string, defaultValue string, evalCtx EvaluationContext, options EvaluationOptions) (string, error)
-			FloatValue(flag string, defaultValue float64, evalCtx EvaluationContext, options EvaluationOptions) (float64, error)
-			IntValue(flag string, defaultValue int64, evalCtx EvaluationContext, options EvaluationOptions) (int64, error)
-			ObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options EvaluationOptions) (interface{}, error)
+			BooleanValueWithContext(flag string, defaultValue bool, evalCtx EvaluationContext, options ...EvaluationOptions) (bool, error)
+			StringValueWithContext(flag string, defaultValue string, evalCtx EvaluationContext, options ...EvaluationOptions) (string, error)
+			FloatValueWithContext(flag string, defaultValue float64, evalCtx EvaluationContext, options ...EvaluationOptions) (float64, error)
+			IntValueWithContext(flag string, defaultValue int64, evalCtx EvaluationContext, options ...EvaluationOptions) (int64, error)
+			ObjectValueWithContext(flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...EvaluationOptions) (interface{}, error)
 			BooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options EvaluationOptions) (EvaluationDetails, error)
 			StringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options EvaluationOptions) (EvaluationDetails, error)
 			FloatValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options EvaluationOptions) (EvaluationDetails, error)
@@ -135,7 +135,7 @@ func TestRequirement_3_2_2(t *testing.T) {
 	flatCtx := flattenContext(expectedMergedEvalCtx)
 	mockProvider.EXPECT().StringEvaluation(gomock.Any(), gomock.Any(), flatCtx)
 
-	_, err := client.StringValue("foo", "bar", invocationEvalCtx, EvaluationOptions{})
+	_, err := client.stringValue("foo", "bar", invocationEvalCtx, EvaluationOptions{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/openfeature/hooks_test.go
+++ b/pkg/openfeature/hooks_test.go
@@ -565,11 +565,11 @@ func TestRequirement_4_4_1(t *testing.T) {
 
 		// EvaluationOptions contains the hooks registered at invocation
 		type requirement interface {
-			BooleanValue(flag string, defaultValue bool, evalCtx EvaluationContext, options EvaluationOptions) (bool, error)
-			StringValue(flag string, defaultValue string, evalCtx EvaluationContext, options EvaluationOptions) (string, error)
-			FloatValue(flag string, defaultValue float64, evalCtx EvaluationContext, options EvaluationOptions) (float64, error)
-			IntValue(flag string, defaultValue int64, evalCtx EvaluationContext, options EvaluationOptions) (int64, error)
-			ObjectValue(flag string, defaultValue interface{}, evalCtx EvaluationContext, options EvaluationOptions) (interface{}, error)
+			BooleanValue(flag string, defaultValue bool, options ...EvaluationOptions) (bool, error)
+			StringValue(flag string, defaultValue string, options ...EvaluationOptions) (string, error)
+			FloatValue(flag string, defaultValue float64, options ...EvaluationOptions) (float64, error)
+			IntValue(flag string, defaultValue int64, options ...EvaluationOptions) (int64, error)
+			ObjectValue(flag string, defaultValue interface{}, options ...EvaluationOptions) (interface{}, error)
 			BooleanValueDetails(flag string, defaultValue bool, evalCtx EvaluationContext, options EvaluationOptions) (EvaluationDetails, error)
 			StringValueDetails(flag string, defaultValue string, evalCtx EvaluationContext, options EvaluationOptions) (EvaluationDetails, error)
 			FloatValueDetails(flag string, defaultValue float64, evalCtx EvaluationContext, options EvaluationOptions) (EvaluationDetails, error)


### PR DESCRIPTION
Signed-off-by: Skye Gill <gill.skye95@gmail.com>