### PR TITLE
fix: add reason indicating pseudorandom split

### DIFF
--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -5,6 +5,7 @@ import "errors"
 const (
 	DISABLED        string = "disabled"     // variant returned because feature is disabled
 	TARGETING_MATCH string = "target match" // variant returned because matched target rule
+	SPLIT           string = "split"        // variant returned because of pseudorandom assignment
 	DEFAULT         string = "default"      // variant returned the default
 	UNKNOWN         string = "unknown"      // variant returned for unknown reason
 	ERROR           string = "error"        // variant returned due to error


### PR DESCRIPTION
Adding const for SPLIT reason. 