### PR TITLE
Client uses value returned by provider

### DIFF
--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -590,6 +590,7 @@ func (c Client) evaluate(
 		return evalDetails, err
 	}
 	if resolution.Value != nil {
+		evalDetails.Value = resolution.Value
 		evalDetails.ResolutionDetail = resolution.ResolutionDetail()
 	}
 


### PR DESCRIPTION
Signed-off-by: Robert Grassian <robert.grassian@split.io>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Sets the Evaluation Detail's `Value` to be the returned value from the provider.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->
Added test