### PR TITLE
chore: add 1.4.2, 1.4.5, 1.4.6 tests

### DIFF
--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -111,18 +111,18 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 	defer t.Cleanup(initSingleton)
 	client := NewClient("test-client")
 	const (
-		BooleanValue = 	true
-		StringValue =		"str"
-		IntValue = 			10
-		FloatValue = 		0.1
+		booleanValue = true
+		stringValue  = "str"
+		intValue     = 10
+		floatValue   = 0.1
 
-		BooleanVariant = 	"boolean"
-		StringVariant =		"string"
-		IntVariant = 			"ten"
-		FloatVariant = 		"tenth"
-		ObjectVariant = 		"object"
+		booleanVariant = "boolean"
+		stringVariant  = "string"
+		intVariant     = "ten"
+		floatVariant   = "tenth"
+		objectVariant  = "object"
 
-		TestReason = "TEST_REASON"
+		testReason = "TEST_REASON"
 	)
 	var objectValue = map[string]int{"foo": 1, "bar": 2}
 
@@ -130,126 +130,126 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 	mockProvider := NewMockFeatureProvider(ctrl)
 	mockProvider.EXPECT().Metadata().AnyTimes()
 	mockProvider.EXPECT().Hooks().AnyTimes()
-	
-	mockProvider.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-	Return(BoolResolutionDetail{
-		Value: BooleanValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{
-			Variant: BooleanVariant,
-			Reason: TestReason,
-		},
-	})
-
-	mockProvider.EXPECT().StringEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-	Return(StringResolutionDetail{
-		Value: StringValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{
-			Variant: StringVariant,
-			Reason: TestReason,
-		},
-	})
-
-	mockProvider.EXPECT().IntEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-	Return(IntResolutionDetail{
-		Value: IntValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{
-			Variant: IntVariant,
-			Reason: TestReason,
-		},
-	})
-
-	mockProvider.EXPECT().FloatEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-	Return(FloatResolutionDetail{
-		Value: FloatValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{
-			Variant: FloatVariant,
-			Reason: TestReason,
-		},
-	})
-
-	mockProvider.EXPECT().ObjectEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-	Return(InterfaceResolutionDetail{
-		Value: objectValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{
-			Variant:ObjectVariant,
-			Reason: TestReason,
-		},
-	})
-
 	SetProvider(mockProvider)
 
 	flagKey := "foo"
 
 	t.Run("BooleanValueDetails", func(t *testing.T) {
+		mockProvider.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(BoolResolutionDetail{
+				Value: booleanValue,
+				ProviderResolutionDetail: ProviderResolutionDetail{
+					Variant: booleanVariant,
+					Reason:  testReason,
+				},
+			})
+
 		evDetails, err := client.BooleanValueDetails(context.Background(), flagKey, false, EvaluationContext{})
 		if err != nil {
 			t.Error(err)
 		}
-		if (evDetails.Value != BooleanValue) {
+		if evDetails.Value != booleanValue {
 			t.Error(err)
 		}
 	})
 
 	t.Run("StringValueDetails", func(t *testing.T) {
+		mockProvider.EXPECT().StringEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(StringResolutionDetail{
+				Value: stringValue,
+				ProviderResolutionDetail: ProviderResolutionDetail{
+					Variant: stringVariant,
+					Reason:  testReason,
+				},
+			})
+
 		evDetails, err := client.StringValueDetails(context.Background(), flagKey, "", EvaluationContext{})
+
 		if err != nil {
 			t.Error(err)
 		}
-		if (evDetails.Value != StringValue) {
+		if evDetails.Value != stringValue {
 			t.Error("Incorrect value returned!")
 		}
-		if (evDetails.Variant != StringVariant) {
+		if evDetails.Variant != stringVariant {
 			t.Error("Incorrect variant returned!")
 		}
-		if (evDetails.Reason != TestReason) {
+		if evDetails.Reason != testReason {
 			t.Error("Incorrect reason returned!")
 		}
 	})
 
 	t.Run("FloatValueDetails", func(t *testing.T) {
+		mockProvider.EXPECT().FloatEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(FloatResolutionDetail{
+				Value: floatValue,
+				ProviderResolutionDetail: ProviderResolutionDetail{
+					Variant: floatVariant,
+					Reason:  testReason,
+				},
+			})
+
 		evDetails, err := client.FloatValueDetails(context.Background(), flagKey, 0, EvaluationContext{})
 		if err != nil {
 			t.Error(err)
 		}
-		if (evDetails.Value != FloatValue) {
+		if evDetails.Value != floatValue {
 			t.Error("Incorrect value returned!")
 		}
-		if (evDetails.Variant != FloatVariant) {
+		if evDetails.Variant != floatVariant {
 			t.Error("Incorrect variant returned!")
 		}
-		if (evDetails.Reason != TestReason) {
+		if evDetails.Reason != testReason {
 			t.Error("Incorrect reason returned!")
 		}
 	})
 
 	t.Run("IntValueDetails", func(t *testing.T) {
+		mockProvider.EXPECT().IntEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(IntResolutionDetail{
+				Value: intValue,
+				ProviderResolutionDetail: ProviderResolutionDetail{
+					Variant: intVariant,
+					Reason:  testReason,
+				},
+			})
+
 		evDetails, err := client.IntValueDetails(context.Background(), flagKey, 0, EvaluationContext{})
 		if err != nil {
 			t.Error(err)
 		}
-		if (evDetails.Value != IntValue) {
+		if evDetails.Value != intValue {
 			t.Error("Incorrect value returned!")
 		}
-		if (evDetails.Variant != IntVariant) {
+		if evDetails.Variant != intVariant {
 			t.Error("Incorrect variant returned!")
 		}
-		if (evDetails.Reason != TestReason) {
+		if evDetails.Reason != testReason {
 			t.Error("Incorrect reason returned!")
 		}
 	})
 
 	t.Run("ObjectValueDetails", func(t *testing.T) {
+		mockProvider.EXPECT().ObjectEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(InterfaceResolutionDetail{
+				Value: objectValue,
+				ProviderResolutionDetail: ProviderResolutionDetail{
+					Variant: objectVariant,
+					Reason:  testReason,
+				},
+			})
+
 		evDetails, err := client.ObjectValueDetails(context.Background(), flagKey, nil, EvaluationContext{})
 		if err != nil {
 			t.Error(err)
 		}
-		if (!reflect.DeepEqual(evDetails.Value, objectValue)) {
+		if !reflect.DeepEqual(evDetails.Value, objectValue) {
 			t.Error("Incorrect value returned!")
 		}
-		if (evDetails.Variant != ObjectVariant) {
+		if evDetails.Variant != objectVariant {
 			t.Error("Incorrect variant returned!")
 		}
-		if (evDetails.Reason != TestReason) {
+		if evDetails.Reason != testReason {
 			t.Error("Incorrect reason returned!")
 		}
 	})

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -123,6 +123,10 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 		objectVariant  = "object"
 
 		testReason = "TEST_REASON"
+
+		incorrectValue   = "Incorrect value returned!"
+		incorrectVariant = "Incorrect variant returned!"
+		incorrectReason  = "Incorrect reason returned!"
 	)
 	var objectValue = map[string]interface{}{"foo": 1, "bar": true, "baz": "buz"}
 
@@ -169,13 +173,13 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 			t.Error(err)
 		}
 		if evDetails.Value != stringValue {
-			t.Error("Incorrect value returned!")
+			t.Error(incorrectValue)
 		}
 		if evDetails.Variant != stringVariant {
-			t.Error("Incorrect variant returned!")
+			t.Error(incorrectVariant)
 		}
 		if evDetails.Reason != testReason {
-			t.Error("Incorrect reason returned!")
+			t.Error(incorrectReason)
 		}
 	})
 
@@ -194,13 +198,13 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 			t.Error(err)
 		}
 		if evDetails.Value != floatValue {
-			t.Error("Incorrect value returned!")
+			t.Error(incorrectValue)
 		}
 		if evDetails.Variant != floatVariant {
-			t.Error("Incorrect variant returned!")
+			t.Error(incorrectVariant)
 		}
 		if evDetails.Reason != testReason {
-			t.Error("Incorrect reason returned!")
+			t.Error(incorrectReason)
 		}
 	})
 
@@ -219,13 +223,13 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 			t.Error(err)
 		}
 		if evDetails.Value != intValue {
-			t.Error("Incorrect value returned!")
+			t.Error(incorrectValue)
 		}
 		if evDetails.Variant != intVariant {
-			t.Error("Incorrect variant returned!")
+			t.Error(incorrectVariant)
 		}
 		if evDetails.Reason != testReason {
-			t.Error("Incorrect reason returned!")
+			t.Error(incorrectReason)
 		}
 	})
 
@@ -244,13 +248,13 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 			t.Error(err)
 		}
 		if !reflect.DeepEqual(evDetails.Value, objectValue) {
-			t.Error("Incorrect value returned!")
+			t.Error(incorrectValue)
 		}
 		if evDetails.Variant != objectVariant {
-			t.Error("Incorrect variant returned!")
+			t.Error(incorrectVariant)
 		}
 		if evDetails.Reason != testReason {
-			t.Error("Incorrect reason returned!")
+			t.Error(incorrectReason)
 		}
 	})
 }

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -124,7 +124,7 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 
 		testReason = "TEST_REASON"
 	)
-	var objectValue = map[string]int{"foo": 1, "bar": 2}
+	var objectValue = map[string]interface{}{"foo": 1, "bar": true, "baz": "buz"}
 
 	ctrl := gomock.NewController(t)
 	mockProvider := NewMockFeatureProvider(ctrl)


### PR DESCRIPTION
- adds tests for 1.4.2, 1.4.5, 1.4.6

@rgrassian-split found this issue, this is just improving the tests around it. It added assertions for `reason` and `variant` and tests for all resolvers.

When Robert's fix is removed, all these tests fail:

```
--- FAIL: TestRequirement_1_4_2__1_4_5__1_4_6 (0.00s)
    --- FAIL: TestRequirement_1_4_2__1_4_5__1_4_6/BooleanValueDetails (0.00s)
        client_test.go:189: <nil>
    --- FAIL: TestRequirement_1_4_2__1_4_5__1_4_6/StringValueDetails (0.00s)
        client_test.go:199: Incorrect value returned!
    --- FAIL: TestRequirement_1_4_2__1_4_5__1_4_6/FloatValueDetails (0.00s)
        client_test.go:215: Incorrect value returned!
    --- FAIL: TestRequirement_1_4_2__1_4_5__1_4_6/IntValueDetails (0.00s)
        client_test.go:231: Incorrect value returned!
    --- FAIL: TestRequirement_1_4_2__1_4_5__1_4_6/ObjectValueDetails (0.00s)
        client_test.go:247: Incorrect value returned!
```