### PR TITLE
fix: resolution error only includes the code

### DIFF
--- a/pkg/openfeature/logger.go
+++ b/pkg/openfeature/logger.go
@@ -21,7 +21,9 @@ func (l logger) Enabled(level int) bool { return true }
 
 func (l logger) Info(level int, msg string, keysAndValues ...interface{}) {}
 
-func (l logger) Error(err error, msg string, keysAndValues ...interface{}) { log.Println(err) }
+func (l logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	log.Println("openfeature:", err)
+}
 
 func (l logger) WithValues(keysAndValues ...interface{}) logr.LogSink { return l }
 

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -47,8 +47,8 @@ type FeatureProvider interface {
 // N.B we could use generics but to support older versions of go for now we will have type specific resolution
 // detail
 type ProviderResolutionDetail struct {
-	Reason          Reason
 	ResolutionError ResolutionError
+	Reason          Reason
 	Variant         string
 }
 

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -47,8 +47,8 @@ type FeatureProvider interface {
 // N.B we could use generics but to support older versions of go for now we will have type specific resolution
 // detail
 type ProviderResolutionDetail struct {
-	ResolutionError ResolutionError
 	Reason          Reason
+	ResolutionError ResolutionError
 	Variant         string
 }
 
@@ -65,7 +65,7 @@ func (p ProviderResolutionDetail) Error() error {
 	if p.ResolutionError.code == "" {
 		return nil
 	}
-	return errors.New(string(p.ResolutionError.code))
+	return errors.New(p.ResolutionError.Error())
 }
 
 // BoolResolutionDetail provides a resolution detail with boolean type

--- a/pkg/openfeature/resolution_error.go
+++ b/pkg/openfeature/resolution_error.go
@@ -1,5 +1,7 @@
 package openfeature
 
+import "fmt"
+
 type ErrorCode string
 
 const (
@@ -28,7 +30,7 @@ type ResolutionError struct {
 }
 
 func (r ResolutionError) Error() string {
-	return string(r.code)
+	return fmt.Sprintf("%s: %s", r.code, r.message)
 }
 
 // NewProviderNotReadyResolutionError constructs a resolution error with code PROVIDER_NOT_READY


### PR DESCRIPTION
## This PR
Adds the error message to the formatted error string. 
Makes it clear when logged that the error originates from the OpenFeature SDK.

### Related Issues

Fixes #94
