### PR TITLE
fix: authorize nil value for object evaluation

### DIFF
--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -639,10 +639,8 @@ func (c *Client) evaluate(
 		evalDetails.Reason = ErrorReason
 		return evalDetails, err
 	}
-	if resolution.Value != nil {
-		evalDetails.Value = resolution.Value
-		evalDetails.ResolutionDetail = resolution.ResolutionDetail()
-	}
+	evalDetails.Value = resolution.Value
+	evalDetails.ResolutionDetail = resolution.ResolutionDetail()
 
 	if err := c.afterHooks(hookCtx, providerInvocationClientApiHooks, evalDetails, options); err != nil {
 		c.logger().Error(

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -873,6 +873,7 @@ func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
 
 	variant := "variant1"
 	reason := TargetingMatchReason
+	var value interface{} = nil
 
 	mockProvider := NewMockFeatureProvider(ctrl)
 	mockProvider.EXPECT().Metadata().AnyTimes()
@@ -880,7 +881,7 @@ func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
 	SetProvider(mockProvider)
 	mockProvider.EXPECT().ObjectEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(InterfaceResolutionDetail{
-			Value: nil,
+			Value: value,
 			ProviderResolutionDetail: ProviderResolutionDetail{
 				Variant: variant,
 				Reason:  reason,
@@ -889,6 +890,9 @@ func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
 
 	client := NewClient("test")
 	evDetails, _ := client.ObjectValueDetails(context.Background(), "foo", nil, EvaluationContext{})
+	if evDetails.Value != value {
+		t.Errorf("unexpected value returned (expected: %s, value: %s)", value, evDetails.Value)
+	}
 	if evDetails.Variant != variant {
 		t.Errorf("unexpected variant returned (expected: %s, value: %s)", variant, evDetails.Variant)
 	}

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -889,7 +889,10 @@ func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
 		})
 
 	client := NewClient("test")
-	evDetails, _ := client.ObjectValueDetails(context.Background(), "foo", nil, EvaluationContext{})
+	evDetails, err := client.ObjectValueDetails(context.Background(), "foo", nil, EvaluationContext{})
+	if err != nil {
+		t.Error("should not return an error")
+	}
 	if evDetails.Value != value {
 		t.Errorf("unexpected value returned (expected: %s, value: %s)", value, evDetails.Value)
 	}

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -891,7 +891,7 @@ func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
 	client := NewClient("test")
 	evDetails, err := client.ObjectValueDetails(context.Background(), "foo", nil, EvaluationContext{})
 	if err != nil {
-		t.Error("should not return an error")
+		t.Errorf("should not return an error: %s", err.Error())
 	}
 	if evDetails.Value != value {
 		t.Errorf("unexpected value returned (expected: %s, value: %s)", value, evDetails.Value)


### PR DESCRIPTION
## This PR
Allow using a `nil` value when calling the `ObjectValueDetails` method.

### Related Issues
Fixes #117