### PR TITLE
feat: HookContext constructor

### DIFF
--- a/pkg/openfeature/hooks.go
+++ b/pkg/openfeature/hooks.go
@@ -67,6 +67,7 @@ func (h HookContext) EvaluationContext() EvaluationContext {
 }
 
 // NewHookContext constructs HookContext
+// Allows for simplified hook test cases while maintaining immutability
 func NewHookContext(
 	flagKey string,
 	flagType Type,

--- a/pkg/openfeature/hooks.go
+++ b/pkg/openfeature/hooks.go
@@ -66,15 +66,35 @@ func (h HookContext) EvaluationContext() EvaluationContext {
 	return h.evaluationContext
 }
 
+// NewHookContext constructs HookContext
+func NewHookContext(
+	flagKey string,
+	flagType Type,
+	defaultValue interface{},
+	clientMetadata ClientMetadata,
+	providerMetadata Metadata,
+	evaluationContext EvaluationContext,
+) HookContext {
+	return HookContext{
+		flagKey:           flagKey,
+		flagType:          flagType,
+		defaultValue:      defaultValue,
+		clientMetadata:    clientMetadata,
+		providerMetadata:  providerMetadata,
+		evaluationContext: evaluationContext,
+	}
+}
+
 // check at compile time that UnimplementedHook implements the Hook interface
 var _ Hook = UnimplementedHook{}
 
 // UnimplementedHook implements all hook methods with empty functions
 // Include UnimplementedHook in your hook struct to avoid defining empty functions
 // e.g.
-// type MyHook struct {
-//   UnimplementedHook
-// }
+//
+//	type MyHook struct {
+//	  UnimplementedHook
+//	}
 type UnimplementedHook struct{}
 
 func (u UnimplementedHook) Before(hookContext HookContext, hookHints HookHints) (*EvaluationContext, error) {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds `HookContext` constructor

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->
In order to properly unit test a `Hook` there must be some way of constructing a `HookContext` so that the `Before`, `After`, `Finally` and `Error` methods can be invoked directly.
Adding the constructor allows for the fields to remain unexpected and immutable, whilst also allowing for proper hook testing without an abstraction layer.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

