### PR TITLE
feat: NewClientMetadata constructor 

### DIFF
--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -32,6 +32,14 @@ type ClientMetadata struct {
 	name string
 }
 
+// NewClientMetadata constructs ClientMetadata
+// Allows for simplified hook test cases while maintaining immutability
+func NewClientMetadata(name string) ClientMetadata {
+	return ClientMetadata{
+		name: name,
+	}
+}
+
 // Name returns the client's name
 func (cm ClientMetadata) Name() string {
 	return cm.name


### PR DESCRIPTION
Signed-off-by: James Milligan <james@omnant.co.uk>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds `ClientMetadata` constructor

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->
https://github.com/open-feature/go-sdk/pull/130
this pr added a constructor for `HookContext`, however, ClientMetadata contains the unexported field `name` and as such cannot be set in hook unit tests external to this package.


### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

