### PR TITLE
chore: strictly load testing-flags.json when needed

### DIFF
--- a/integration/caching_test.go
+++ b/integration/caching_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -20,16 +19,19 @@ const flagConfigurationPath = "../test-harness/testing-flags.json"
 
 var testingFlags eval.Flags
 
-func init() {
-	file, err := os.Open(flagConfigurationPath)
+func loadFlagConfiguration(path string) (eval.Flags, error) {
+	file, err := os.Open(path)
 	if err != nil {
-		log.Fatal(err)
+		return eval.Flags{}, err
 	}
 
-	err = json.NewDecoder(file).Decode(&testingFlags)
+	var flags eval.Flags
+	err = json.NewDecoder(file).Decode(&flags)
 	if err != nil {
-		log.Fatal(fmt.Errorf("decode testing-flags.json: %v", err))
+		return eval.Flags{}, fmt.Errorf("decode %s: %v", path, err)
 	}
+
+	return flags, nil
 }
 
 func theFlagsConfigurationWithKeyIsUpdatedToDefaultVariant(flagKey, defaultVariant string) error {
@@ -265,6 +267,12 @@ func InitializeCachingScenario(ctx *godog.ScenarioContext) {
 func TestCaching(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
+	}
+
+	var err error
+	testingFlags, err = loadFlagConfiguration(flagConfigurationPath)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	suite := godog.TestSuite{


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

Stops attempt to load testing-flags.json in unit testing.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

