### PR TITLE
chore: rename integration tests e2e

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ When writing a test to cover a spec requirement use the test naming convention `
 
 Run unit tests with `make test`.
 
-#### Integration tests
+#### End-to-End tests
 
-The continuous integration runs a set of [gherkin integration tests](https://github.com/open-feature/test-harness/blob/main/features) using the [flagd provider](https://github.com/open-feature/go-sdk-contrib/tree/main/providers/flagd), [flagd](https://github.com/open-feature/flagd) and [the flagd test module](https://github.com/open-feature/go-sdk-contrib/tree/main/tests/flagd).
+The continuous integration runs a set of [gherkin e2e tests](https://github.com/open-feature/test-harness/blob/main/features) using the [flagd provider](https://github.com/open-feature/go-sdk-contrib/tree/main/providers/flagd), [flagd](https://github.com/open-feature/flagd) and [the flagd test module](https://github.com/open-feature/go-sdk-contrib/tree/main/tests/flagd).
 If you'd like to run them locally, first pull the `test-harness` git submodule
 ```
 git submodule update --init --recursive
@@ -45,7 +45,7 @@ docker run -p 8013:8013 -v $PWD/test-harness/testing-flags.json:/testing-flags.j
 ```
  and finally run
 ```
-make integration-test
+make e2e-test
 ```
 
 #### Fuzzing

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-.PHONY: mockgen test lint integration-test
+.PHONY: mockgen test lint e2e-test
 mockgen:
 	mockgen -source=pkg/openfeature/provider.go -destination=pkg/openfeature/provider_mock_test.go -package=openfeature
 	mockgen -source=pkg/openfeature/hooks.go -destination=pkg/openfeature/hooks_mock_test.go -package=openfeature
 	mockgen -source=pkg/openfeature/mutex.go -destination=pkg/openfeature/mutex_mock_test.go -package=openfeature
 test:
 	go test --short -cover ./...
-integration-test: # dependent on: docker run -p 8013:8013 -v $PWD/test-harness/testing-flags.json:/testing-flags.json ghcr.io/open-feature/flagd-testbed:latest
+e2e-test: # dependent on: docker run -p 8013:8013 -v $PWD/test-harness/testing-flags.json:/testing-flags.json ghcr.io/open-feature/flagd-testbed:latest
 	go test -cover ./...
 	cd test-harness; git restore testing-flags.json; cd .. # reset testing-flags.json
 

--- a/e2e/caching_test.go
+++ b/e2e/caching_test.go
@@ -1,4 +1,4 @@
-package integration_test
+package e2e_test
 
 import (
 	"testing"

--- a/e2e/evaluation_fuzz_test.go
+++ b/e2e/evaluation_fuzz_test.go
@@ -1,4 +1,4 @@
-package integration_test
+package e2e_test
 
 import (
 	"context"

--- a/e2e/evaluation_test.go
+++ b/e2e/evaluation_test.go
@@ -1,10 +1,10 @@
-package integration_test
+package e2e_test
 
 import (
 	"testing"
 
 	"github.com/cucumber/godog"
-	"github.com/open-feature/go-sdk-contrib/tests/flagd/pkg/integration"
+	e2e "github.com/open-feature/go-sdk-contrib/tests/flagd/pkg/integration"
 )
 
 func TestEvaluation(t *testing.T) {
@@ -14,7 +14,7 @@ func TestEvaluation(t *testing.T) {
 
 	suite := godog.TestSuite{
 		Name:                "evaluation.feature",
-		ScenarioInitializer: integration.InitializeEvaluationScenario(),
+		ScenarioInitializer: e2e.InitializeEvaluationScenario(),
 		Options: &godog.Options{
 			Format:   "pretty",
 			Paths:    []string{"../test-harness/features/evaluation.feature"},


### PR DESCRIPTION
As has been brought up a few times, "end-to-end" is probably a better term for these tests, since they startup multiple processes and do inter-process communication streams with real (not mocked) artifacts.

No functional changes. I did use git mv to try to preserve history as best as possible.