### PR TITLE
feat: add flag metadata field

### DIFF
--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -218,7 +218,7 @@ func (f FlagMetadata) GetInt(key string) (int64, error) {
 	case int64:
 		return v.(int64), nil
 	default:
-		return 0, fmt.Errorf("wrong type for key %s, expected integer, got %T", key, t)return 0, fmt.Errorf("wrong type for key %s, expected string, got %T", key, t)
+		return 0, fmt.Errorf("wrong type for key %s, expected integer, got %T", key, t)
 	}
 }
 

--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -218,7 +218,7 @@ func (f FlagMetadata) GetInt(key string) (int64, error) {
 	case int64:
 		return v.(int64), nil
 	default:
-		return 0, fmt.Errorf("wrong type for key %s, expected string, got %T", key, t)
+		return 0, fmt.Errorf("wrong type for key %s, expected integer, got %T", key, t)return 0, fmt.Errorf("wrong type for key %s, expected string, got %T", key, t)
 	}
 }
 
@@ -234,7 +234,7 @@ func (f FlagMetadata) GetFloat(key string) (float64, error) {
 	case float64:
 		return v.(float64), nil
 	default:
-		return 0, fmt.Errorf("wrong type for key %s, expected string, got %T", key, t)
+		return 0, fmt.Errorf("wrong type for key %s, expected float, got %T", key, t)
 	}
 }
 

--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -164,11 +164,69 @@ type ResolutionDetail struct {
 	Reason       Reason
 	ErrorCode    ErrorCode
 	ErrorMessage string
-	FlagMetadata *FlagMetadata
+	FlagMetadata FlagMetadata
 }
 
-// FlagMetadata provides a mechanism for providers to surface additional information about a feature flag
+// A structure which supports definition of arbitrary properties, with keys of type string, and values of type boolean, string, int64 or float64.
+//
+// This structure is populated by a provider for use by an Application Author (via the Evaluation API) or an Application Integrator (via hooks).
 type FlagMetadata map[string]interface{}
+
+// Fetch string value from FlagMetadata, returns an error if the key does not exist, or, the value is of the wrong type
+func (f FlagMetadata) GetString(key string) (string, error) {
+	v, ok := f[key]
+	if !ok {
+		return "", fmt.Errorf("key %s does not exist in FlagMetadata", key)
+	}
+	switch t := v.(type) {
+	case string:
+		return v.(string), nil
+	default:
+		return "", fmt.Errorf("wrong type for key %s, expected string, got %T", key, t)
+	}
+}
+
+// Fetch bool value from FlagMetadata, returns an error if the key does not exist, or, the value is of the wrong type
+func (f FlagMetadata) GetBool(key string) (bool, error) {
+	v, ok := f[key]
+	if !ok {
+		return false, fmt.Errorf("key %s does not exist in FlagMetadata", key)
+	}
+	switch t := v.(type) {
+	case bool:
+		return v.(bool), nil
+	default:
+		return false, fmt.Errorf("wrong type for key %s, expected bool, got %T", key, t)
+	}
+}
+
+// Fetch int64 value from FlagMetadata, returns an error if the key does not exist, or, the value is of the wrong type
+func (f FlagMetadata) GetInt(key string) (int64, error) {
+	v, ok := f[key]
+	if !ok {
+		return 0, fmt.Errorf("key %s does not exist in FlagMetadata", key)
+	}
+	switch t := v.(type) {
+	case int64:
+		return v.(int64), nil
+	default:
+		return 0, fmt.Errorf("wrong type for key %s, expected string, got %T", key, t)
+	}
+}
+
+// Fetch float64 value from FlagMetadata, returns an error if the key does not exist, or, the value is of the wrong type
+func (f FlagMetadata) GetFloat(key string) (float64, error) {
+	v, ok := f[key]
+	if !ok {
+		return 0, fmt.Errorf("key %s does not exist in FlagMetadata", key)
+	}
+	switch t := v.(type) {
+	case float64:
+		return v.(float64), nil
+	default:
+		return 0, fmt.Errorf("wrong type for key %s, expected string, got %T", key, t)
+	}
+}
 
 // Option applies a change to EvaluationOptions
 type Option func(*EvaluationOptions)

--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -207,6 +207,14 @@ func (f FlagMetadata) GetInt(key string) (int64, error) {
 		return 0, fmt.Errorf("key %s does not exist in FlagMetadata", key)
 	}
 	switch t := v.(type) {
+	case int:
+		return int64(v.(int)), nil
+	case int8:
+		return int64(v.(int8)), nil
+	case int16:
+		return int64(v.(int16)), nil
+	case int32:
+		return int64(v.(int32)), nil
 	case int64:
 		return v.(int64), nil
 	default:
@@ -221,6 +229,8 @@ func (f FlagMetadata) GetFloat(key string) (float64, error) {
 		return 0, fmt.Errorf("key %s does not exist in FlagMetadata", key)
 	}
 	switch t := v.(type) {
+	case float32:
+		return float64(v.(float32)), nil
 	case float64:
 		return v.(float64), nil
 	default:

--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -164,7 +164,11 @@ type ResolutionDetail struct {
 	Reason       Reason
 	ErrorCode    ErrorCode
 	ErrorMessage string
+	FlagMetadata *FlagMetadata
 }
+
+// FlagMetadata provides a mechanism for providers to surface additional information about a feature flag
+type FlagMetadata map[string]interface{}
 
 // Option applies a change to EvaluationOptions
 type Option func(*EvaluationOptions)

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -1032,24 +1032,27 @@ func TestFlagMetadataAccessors(t *testing.T) {
 
 	t.Run("int", func(t *testing.T) {
 		expectedValue := int64(12)
-		key := "int"
-		key2 := "not-int"
 		metadata := FlagMetadata{
-			key:  expectedValue,
-			key2: true,
+			"int":    int(12),
+			"int8":   int8(12),
+			"int16":  int16(12),
+			"int32":  int32(12),
+			"int164": int32(12),
 		}
-		val, err := metadata.GetInt(key)
-		if err != nil {
-			t.Error("unexpected error value, expected nil", err)
+		for k, _ := range metadata {
+			val, err := metadata.GetInt(k)
+			if err != nil {
+				t.Error("unexpected error value, expected nil", err)
+			}
+			if val != expectedValue {
+				t.Errorf("wrong value returned from FlagMetadata, expected %b, got %b", val, expectedValue)
+			}
 		}
-		if val != expectedValue {
-			t.Errorf("wrong value returned from FlagMetadata, expected %b, got %b", val, expectedValue)
+
+		metadata = FlagMetadata{
+			"not-int": true,
 		}
-		val, err = metadata.GetInt(key2)
-		if err == nil {
-			t.Error("unexpected error value", err)
-		}
-		val, err = metadata.GetInt("not-in-map")
+		_, err := metadata.GetInt("not-int")
 		if err == nil {
 			t.Error("unexpected error value", err)
 		}
@@ -1057,24 +1060,24 @@ func TestFlagMetadataAccessors(t *testing.T) {
 
 	t.Run("float", func(t *testing.T) {
 		expectedValue := float64(12)
-		key := "float"
-		key2 := "not-float"
 		metadata := FlagMetadata{
-			key:  expectedValue,
-			key2: true,
+			"float32": float32(12),
+			"float64": float64(12),
 		}
-		val, err := metadata.GetFloat(key)
-		if err != nil {
-			t.Error("unexpected error value, expected nil", err)
+		for k, _ := range metadata {
+			val, err := metadata.GetFloat(k)
+			if err != nil {
+				t.Error("unexpected error value, expected nil", err)
+			}
+			if val != expectedValue {
+				t.Errorf("wrong value returned from FlagMetadata, expected %b, got %b", val, expectedValue)
+			}
 		}
-		if val != expectedValue {
-			t.Errorf("wrong value returned from FlagMetadata, expected %f, got %f", val, expectedValue)
+
+		metadata = FlagMetadata{
+			"not-float": true,
 		}
-		val, err = metadata.GetFloat(key2)
-		if err == nil {
-			t.Error("unexpected error value", err)
-		}
-		val, err = metadata.GetFloat("not-in-map")
+		_, err := metadata.GetInt("not-float")
 		if err == nil {
 			t.Error("unexpected error value", err)
 		}

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -1056,6 +1056,10 @@ func TestFlagMetadataAccessors(t *testing.T) {
 		if err == nil {
 			t.Error("unexpected error value", err)
 		}
+		_, err = metadata.GetInt("not-in-map")
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
 	})
 
 	t.Run("float", func(t *testing.T) {
@@ -1078,6 +1082,10 @@ func TestFlagMetadataAccessors(t *testing.T) {
 			"not-float": true,
 		}
 		_, err := metadata.GetInt("not-float")
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+		_, err = metadata.GetInt("not-in-map")
 		if err == nil {
 			t.Error("unexpected error value", err)
 		}

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -995,11 +995,11 @@ func TestFlagMetadataAccessors(t *testing.T) {
 		if val != expectedValue {
 			t.Errorf("wrong value returned from FlagMetadata, expected %t, got %t", val, expectedValue)
 		}
-		val, err = metadata.GetBool(key2)
+		_, err = metadata.GetBool(key2)
 		if err == nil {
 			t.Error("unexpected error value", err)
 		}
-		val, err = metadata.GetBool("not-in-map")
+		_, err = metadata.GetBool("not-in-map")
 		if err == nil {
 			t.Error("unexpected error value", err)
 		}
@@ -1020,11 +1020,11 @@ func TestFlagMetadataAccessors(t *testing.T) {
 		if val != expectedValue {
 			t.Errorf("wrong value returned from FlagMetadata, expected %s, got %s", val, expectedValue)
 		}
-		val, err = metadata.GetString(key2)
+		_, err = metadata.GetString(key2)
 		if err == nil {
 			t.Error("unexpected error value", err)
 		}
-		val, err = metadata.GetString("not-in-map")
+		_, err = metadata.GetString("not-in-map")
 		if err == nil {
 			t.Error("unexpected error value", err)
 		}
@@ -1039,7 +1039,7 @@ func TestFlagMetadataAccessors(t *testing.T) {
 			"int32":  int32(12),
 			"int164": int32(12),
 		}
-		for k, _ := range metadata {
+		for k := range metadata {
 			val, err := metadata.GetInt(k)
 			if err != nil {
 				t.Error("unexpected error value, expected nil", err)
@@ -1068,7 +1068,7 @@ func TestFlagMetadataAccessors(t *testing.T) {
 			"float32": float32(12),
 			"float64": float64(12),
 		}
-		for k, _ := range metadata {
+		for k := range metadata {
 			val, err := metadata.GetFloat(k)
 			if err != nil {
 				t.Error("unexpected error value, expected nil", err)

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -660,10 +660,10 @@ func TestRequirement_1_4_13(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if evDetails.FlagMetadata != nil {
+		if !reflect.DeepEqual(evDetails.FlagMetadata, FlagMetadata{}) {
 			t.Errorf(
 				"flag metadata is not as expected in EvaluationDetail, got %v, expected %v",
-				evDetails.FlagMetadata, nil,
+				evDetails.FlagMetadata, FlagMetadata{},
 			)
 		}
 	})

--- a/pkg/openfeature/client_test.go
+++ b/pkg/openfeature/client_test.go
@@ -977,3 +977,106 @@ func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
 		t.Error("not supposed to have an error code")
 	}
 }
+
+func TestFlagMetadataAccessors(t *testing.T) {
+
+	t.Run("bool", func(t *testing.T) {
+		expectedValue := true
+		key := "bool"
+		key2 := "not-bool"
+		metadata := FlagMetadata{
+			key:  expectedValue,
+			key2: "12",
+		}
+		val, err := metadata.GetBool(key)
+		if err != nil {
+			t.Error("unexpected error value, expected nil", err)
+		}
+		if val != expectedValue {
+			t.Errorf("wrong value returned from FlagMetadata, expected %t, got %t", val, expectedValue)
+		}
+		val, err = metadata.GetBool(key2)
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+		val, err = metadata.GetBool("not-in-map")
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+	})
+
+	t.Run("string", func(t *testing.T) {
+		expectedValue := "string"
+		key := "string"
+		key2 := "not-string"
+		metadata := FlagMetadata{
+			key:  expectedValue,
+			key2: true,
+		}
+		val, err := metadata.GetString(key)
+		if err != nil {
+			t.Error("unexpected error value, expected nil", err)
+		}
+		if val != expectedValue {
+			t.Errorf("wrong value returned from FlagMetadata, expected %s, got %s", val, expectedValue)
+		}
+		val, err = metadata.GetString(key2)
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+		val, err = metadata.GetString("not-in-map")
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+	})
+
+	t.Run("int", func(t *testing.T) {
+		expectedValue := int64(12)
+		key := "int"
+		key2 := "not-int"
+		metadata := FlagMetadata{
+			key:  expectedValue,
+			key2: true,
+		}
+		val, err := metadata.GetInt(key)
+		if err != nil {
+			t.Error("unexpected error value, expected nil", err)
+		}
+		if val != expectedValue {
+			t.Errorf("wrong value returned from FlagMetadata, expected %b, got %b", val, expectedValue)
+		}
+		val, err = metadata.GetInt(key2)
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+		val, err = metadata.GetInt("not-in-map")
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+	})
+
+	t.Run("float", func(t *testing.T) {
+		expectedValue := float64(12)
+		key := "float"
+		key2 := "not-float"
+		metadata := FlagMetadata{
+			key:  expectedValue,
+			key2: true,
+		}
+		val, err := metadata.GetFloat(key)
+		if err != nil {
+			t.Error("unexpected error value, expected nil", err)
+		}
+		if val != expectedValue {
+			t.Errorf("wrong value returned from FlagMetadata, expected %f, got %f", val, expectedValue)
+		}
+		val, err = metadata.GetFloat(key2)
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+		val, err = metadata.GetFloat("not-in-map")
+		if err == nil {
+			t.Error("unexpected error value", err)
+		}
+	})
+}

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -18,7 +18,7 @@ const (
 	StaticReason Reason = "STATIC"
 	// CachedReason - the resolved value was retrieved from cache
 	CachedReason Reason = "CACHED"
-	// UnknownReason - the reason for the resolved value could not be determined.	
+	// UnknownReason - the reason for the resolved value could not be determined.
 	UnknownReason Reason = "UNKNOWN"
 	// ErrorReason - the resolved value was the result of an error.
 	ErrorReason Reason = "ERROR"
@@ -54,6 +54,7 @@ type ProviderResolutionDetail struct {
 	ResolutionError ResolutionError
 	Reason          Reason
 	Variant         string
+	FlagMetadata    FlagMetadata
 }
 
 func (p ProviderResolutionDetail) ResolutionDetail() ResolutionDetail {
@@ -62,6 +63,7 @@ func (p ProviderResolutionDetail) ResolutionDetail() ResolutionDetail {
 		Reason:       p.Reason,
 		ErrorCode:    p.ResolutionError.code,
 		ErrorMessage: p.ResolutionError.message,
+		FlagMetadata: p.FlagMetadata,
 	}
 }
 

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -58,12 +58,16 @@ type ProviderResolutionDetail struct {
 }
 
 func (p ProviderResolutionDetail) ResolutionDetail() ResolutionDetail {
+	metadata := FlagMetadata{}
+	if p.FlagMetadata != nil {
+		metadata = p.FlagMetadata
+	}
 	return ResolutionDetail{
 		Variant:      p.Variant,
 		Reason:       p.Reason,
 		ErrorCode:    p.ResolutionError.code,
 		ErrorMessage: p.ResolutionError.message,
-		FlagMetadata: p.FlagMetadata,
+		FlagMetadata: metadata,
 	}
 }
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- implement flag metadata: https://github.com/open-feature/spec/commit/74c373e089ad77bf8cac84f3d93c00c945ff3a8a

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/go-sdk/issues/177

### Notes
<!-- any additional notes for this PR -->

If the flag metadata is not in the provider response, then the returned evaluation details will have a nil value, this can be updated to have an empty map, but IMO its a cleaner implementation to leave this value as nil ([nil slices have length 0](https://go.dev/play/p/_m0EwwCvJ65))

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

