### PR TITLE
feat: EvaluationContext add constructor without TargetingKey

### DIFF
--- a/pkg/openfeature/evaluation_context.go
+++ b/pkg/openfeature/evaluation_context.go
@@ -46,3 +46,10 @@ func NewEvaluationContext(targetingKey string, attributes map[string]interface{}
 		attributes:   attrs,
 	}
 }
+
+// NewTargetlessEvaluationContext constructs an EvaluationContext with an empty targeting key
+//
+// attributes - contextual data used in flag evaluation
+func NewTargetlessEvaluationContext(attributes map[string]interface{}) EvaluationContext {
+	return NewEvaluationContext("", attributes)
+}

--- a/pkg/openfeature/evaluation_context_test.go
+++ b/pkg/openfeature/evaluation_context_test.go
@@ -171,3 +171,17 @@ func TestEvaluationContext_AttributesFuncNotPassedByReference(t *testing.T) {
 		t.Error("mutation of map passed to SetAttributes caused a mutation of its attributes field")
 	}
 }
+
+func TestNewTargetlessEvaluationContext(t *testing.T) {
+	attributes := map[string]interface{}{
+		"foo": "bar",
+	}
+	evalCtx := NewTargetlessEvaluationContext(attributes)
+	if evalCtx.targetingKey != "" {
+		t.Error("targeting key should not be set with NewTargetlessEvaluationContext")
+	}
+
+	if !reflect.DeepEqual(evalCtx.Attributes(), attributes) {
+		t.Errorf("we expect no difference in the attributes")
+	}
+}


### PR DESCRIPTION
## This PR
Based on this [discussion](https://github.com/open-feature/go-sdk/pull/193#discussion_r1276491478) we have discovered that in some cases we want to create an EvaluationContext without Targeting key.

With`NewEvaluationContext` it was mandatory to set a `targetingKey` forcing us to set an empty `targetingKey` sometimes.

In this PR we add a new constructor called `NewTargetlessEvaluationContext` that is doing exactly the same things as `NewEvaluationContext` but does not force you to add a `targetingKey`.

