### PR TITLE
chore: sort imports of go files

### DIFF
--- a/e2e/evaluation_fuzz_test.go
+++ b/e2e/evaluation_fuzz_test.go
@@ -2,10 +2,11 @@ package e2e_test
 
 import (
 	"context"
-	"github.com/open-feature/go-sdk/pkg/openfeature"
-	"github.com/open-feature/go-sdk/pkg/openfeature/memprovider"
 	"strings"
 	"testing"
+
+	"github.com/open-feature/go-sdk/pkg/openfeature"
+	"github.com/open-feature/go-sdk/pkg/openfeature/memprovider"
 )
 
 func setupFuzzClient(f *testing.F) *openfeature.Client {

--- a/e2e/evaluation_test.go
+++ b/e2e/evaluation_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/cucumber/godog"
 	"github.com/open-feature/go-sdk/pkg/openfeature"
 	"github.com/open-feature/go-sdk/pkg/openfeature/memprovider"
-	"strconv"
-	"testing"
 )
 
 var client = openfeature.NewClient("evaluation tests")

--- a/pkg/openfeature/evaluation_context_test.go
+++ b/pkg/openfeature/evaluation_context_test.go
@@ -2,9 +2,10 @@ package openfeature
 
 import (
 	"context"
-	"github.com/golang/mock/gomock"
 	"reflect"
 	"testing"
+
+	"github.com/golang/mock/gomock"
 )
 
 // The `evaluation context` structure MUST define an optional `targeting key` field of type string,

--- a/pkg/openfeature/hooks_test.go
+++ b/pkg/openfeature/hooks_test.go
@@ -893,7 +893,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 		if err != nil {
 			t.Errorf("error setting up provider %v", err)
 		}
-		
+
 		mockProvider.EXPECT().Hooks().AnyTimes()
 
 		hookHints := NewHookHints(map[string]interface{}{"foo": "bar"})

--- a/pkg/openfeature/memprovider/in_memory_provider.go
+++ b/pkg/openfeature/memprovider/in_memory_provider.go
@@ -3,6 +3,7 @@ package memprovider
 import (
 	"context"
 	"fmt"
+
 	"github.com/open-feature/go-sdk/pkg/openfeature"
 )
 

--- a/pkg/openfeature/memprovider/in_memory_provider_test.go
+++ b/pkg/openfeature/memprovider/in_memory_provider_test.go
@@ -2,8 +2,9 @@ package memprovider
 
 import (
 	"context"
-	"github.com/open-feature/go-sdk/pkg/openfeature"
 	"testing"
+
+	"github.com/open-feature/go-sdk/pkg/openfeature"
 )
 
 func TestInMemoryProvider_boolean(t *testing.T) {

--- a/pkg/openfeature/openfeature_test.go
+++ b/pkg/openfeature/openfeature_test.go
@@ -1,13 +1,14 @@
 package openfeature
 
 import (
-	"github.com/go-logr/logr"
-	"github.com/open-feature/go-sdk/pkg/openfeature/internal"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
+
+	"github.com/open-feature/go-sdk/pkg/openfeature/internal"
 )
 
 // The `API`, and any state it maintains SHOULD exist as a global singleton,


### PR DESCRIPTION
## This PR
Sorts imports of go files by running command on root directory.
```
~/go-sdk goimports -w .
```

### Related Issues
N/A

### Notes
In VSCode settings.json
```
   ...
    "[go]": {
        "editor.formatOnSave": true,
        "editor.codeActionsOnSave": {
            "source.organizeImports": true
        },
    },
   ...
```
Also results in it sorts the imports every time onSave.

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
Probably we can setup pre-merge check or pre-commit for go format and lint.

### How to test
N/A

