### PR TITLE
feat: run event handlers immediately, add STALE (0.7.0 compliance)

### DIFF
--- a/pkg/openfeature/event_executor_test.go
+++ b/pkg/openfeature/event_executor_test.go
@@ -824,7 +824,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 // Requirement 5.3.3, Spec version 0.7.0: Handlers attached after the
 // provider is already in the associated state, MUST run immediately
 func TestEventHandler_HandlersRunImmediately(t *testing.T) {
-	t.Run("ready handler runs when provider error", func(t *testing.T) {
+	t.Run("ready handler runs when provider ready", func(t *testing.T) {
 		defer t.Cleanup(initSingleton)
 
 		provider := struct {
@@ -852,7 +852,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 		case <-rsp:
 			break
 		case <-time.After(200 * time.Millisecond):
-			t.Errorf("timed out waiting for ready state callback")
+			t.Errorf("timed out waiting for callback")
 		}
 	})
 
@@ -884,7 +884,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 		case <-rsp:
 			break
 		case <-time.After(200 * time.Millisecond):
-			t.Errorf("timed out waiting for ready state callback")
+			t.Errorf("timed out waiting for callback")
 		}
 	})
 
@@ -916,7 +916,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 		case <-rsp:
 			break
 		case <-time.After(200 * time.Millisecond):
-			t.Errorf("timed out waiting for ready state callback")
+			t.Errorf("timed out waiting for callback")
 		}
 	})
 

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -26,6 +26,7 @@ const (
 	NotReadyState State = "NOT_READY"
 	ReadyState    State = "READY"
 	ErrorState    State = "ERROR"
+	StaleState    State = "STALE"
 
 	ProviderReady        EventType = "PROVIDER_READY"
 	ProviderConfigChange EventType = "PROVIDER_CONFIGURATION_CHANGED"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Add a stale state and ensure event handlers run immediately if the associated provider and the state associated with the handle are compatible.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Resolves #220.

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

