### PR TITLE
chore: revert to CodeCov Action to v3

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -58,4 +58,4 @@ jobs:
       - name: Run tests
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
## This PR

- revert to CodeCov Action to v3

### Notes

There's an ongoing issue with v4.
https://github.com/codecov/codecov-action/issues/1087

