### PR TITLE
chore: improve eventing

### DIFF
--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -189,7 +189,7 @@ func (e *eventExecutor) emitOnRegistration(
 
 	if message != "" {
 		(*callback)(EventDetails{
-			providerName: providerReference.featureProvider.Metadata().Name,
+			ProviderName: providerReference.featureProvider.Metadata().Name,
 			ProviderEventDetails: ProviderEventDetails{
 				Message: message,
 			},
@@ -355,7 +355,7 @@ func (e *eventExecutor) executeHandler(f func(details EventDetails), event Event
 		}()
 
 		f(EventDetails{
-			providerName: event.ProviderName,
+			ProviderName: event.ProviderName,
 			ProviderEventDetails: ProviderEventDetails{
 				Message:       event.Message,
 				FlagChanges:   event.FlagChanges,

--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -35,7 +35,7 @@ func newEventExecutor(logger logr.Logger) *eventExecutor {
 		apiRegistry:            map[EventType][]EventCallback{},
 		scopedRegistry:         map[string]scopedCallback{},
 		logger:                 logger,
-		eventChan:              make(chan eventPayload, 1),
+		eventChan:              make(chan eventPayload, 5),
 	}
 
 	executor.startEventListener()

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -177,8 +177,8 @@ func TestEventHandler_Eventing(t *testing.T) {
 			t.Fatalf("timeout - event did not trigger")
 		}
 
-		if result.providerName != eventingProvider.Metadata().Name {
-			t.Errorf("expected %s, but got %s", eventingProvider.Metadata().Name, result.providerName)
+		if result.ProviderName != eventingProvider.Metadata().Name {
+			t.Errorf("expected %s, but got %s", eventingProvider.Metadata().Name, result.ProviderName)
 		}
 
 		if result.Message != "ReadyMessage" {
@@ -1120,29 +1120,29 @@ func TestEventHandler_multiSubs(t *testing.T) {
 	globalEvents := make(chan string, 10)
 	go func() {
 		for rsp := range rspGlobal {
-			globalEvents <- rsp.providerName
+			globalEvents <- rsp.ProviderName
 		}
 	}()
 
 	clientAEvents := make(chan string, 10)
 	go func() {
 		for rsp := range rspClientA {
-			if rsp.providerName != "providerOther" {
-				t.Errorf("incorrect event provider association, expected %s, got %s", "providerOther", rsp.providerName)
+			if rsp.ProviderName != "providerOther" {
+				t.Errorf("incorrect event provider association, expected %s, got %s", "providerOther", rsp.ProviderName)
 			}
 
-			clientAEvents <- rsp.providerName
+			clientAEvents <- rsp.ProviderName
 		}
 	}()
 
 	clientBEvents := make(chan string, 10)
 	go func() {
 		for rsp := range rspClientB {
-			if rsp.providerName != "providerOther" {
-				t.Errorf("incorrect event provider association, expected %s, got %s", "providerOther", rsp.providerName)
+			if rsp.ProviderName != "providerOther" {
+				t.Errorf("incorrect event provider association, expected %s, got %s", "providerOther", rsp.ProviderName)
 			}
 
-			clientBEvents <- rsp.providerName
+			clientBEvents <- rsp.ProviderName
 		}
 	}()
 

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -109,7 +109,7 @@ type Event struct {
 }
 
 type EventDetails struct {
-	providerName string
+	ProviderName string
 	ProviderEventDetails
 }
 


### PR DESCRIPTION
## This PR

Contains minor improvements on the eventing of the SDK

- Expose the provider name from `EventDetails`
- Add buffer to internal channel handler to improve concurrency: Buffer should theoretically allow us to handle events in order of they are received 