### PR TITLE
feat: blocking provider mutator

### DIFF
--- a/openfeature/api.go
+++ b/openfeature/api.go
@@ -169,9 +169,9 @@ func (api *evaluationAPI) forTransaction(clientName string) (FeatureProvider, []
 // initNewAndShutdownOld is a helper to initialise new FeatureProvider and shutdown the old FeatureProvider.
 func (api *evaluationAPI) initNewAndShutdownOld(newProvider FeatureProvider, oldProvider FeatureProvider, async bool) {
 	if async {
-		go func() {
-			api.eventExecutor.triggerEvent(initializer(newProvider, api.apiCtx), newProvider)
-		}()
+		go func(executor *eventExecutor, ctx EvaluationContext) {
+			executor.triggerEvent(initializer(newProvider, ctx), newProvider)
+		}(api.eventExecutor, api.apiCtx)
 	} else {
 		api.eventExecutor.triggerEvent(initializer(newProvider, api.apiCtx), newProvider)
 	}

--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -327,7 +327,7 @@ func (e *eventExecutor) triggerEvent(event Event, handler FeatureProvider) {
 		}
 	}
 
-	if e.defaultProviderReference.featureProvider != handler {
+	if !reflect.DeepEqual(e.defaultProviderReference.featureProvider, handler) {
 		return
 	}
 

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -72,7 +72,7 @@ func TestEventHandler_Eventing(t *testing.T) {
 			eventingImpl,
 		}
 
-		err := SetProvider(eventingProvider)
+		err := SetProviderAndWait(eventingProvider)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -214,13 +214,13 @@ func TestEventHandler_clientAssociation(t *testing.T) {
 	}
 
 	// default provider
-	err := SetProvider(defaultProvider)
+	err := SetProviderAndWait(defaultProvider)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// named provider(associated to name someClient)
-	err = SetNamedProvider("someClient", struct {
+	err = SetNamedProviderAndWait("someClient", struct {
 		FeatureProvider
 		EventHandler
 	}{
@@ -967,7 +967,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 			},
 		}
 
-		if err := SetProvider(provider); err != nil {
+		if err := SetProviderAndWait(provider); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1001,7 +1001,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 			},
 		}
 
-		if err := SetProvider(provider); err != nil {
+		if err := SetProviderAndWait(provider); err != nil {
 			t.Fatal(err)
 		}
 

--- a/openfeature/openfeature.go
+++ b/openfeature/openfeature.go
@@ -24,6 +24,7 @@ func SetProvider(provider FeatureProvider) error {
 }
 
 // SetProviderAndWait sets the default provider and waits for its initialization.
+// Returns an error if initialization cause error
 func SetProviderAndWait(provider FeatureProvider) error {
 	return api.setProvider(provider, false)
 }
@@ -35,6 +36,7 @@ func SetNamedProvider(clientName string, provider FeatureProvider) error {
 }
 
 // SetNamedProviderAndWait sets a provider mapped to the given Client name and waits for its initialization.
+// Returns an error if initialization cause error
 func SetNamedProviderAndWait(clientName string, provider FeatureProvider) error {
 	return api.setNamedProvider(clientName, provider, false)
 }

--- a/openfeature/openfeature.go
+++ b/openfeature/openfeature.go
@@ -20,13 +20,23 @@ func initSingleton() {
 // SetProvider sets the default provider. Provider initialization is asynchronous and status can be checked from
 // provider status
 func SetProvider(provider FeatureProvider) error {
-	return api.setProvider(provider)
+	return api.setProvider(provider, true)
+}
+
+// SetProviderAndWait sets the default provider and waits for its initialization.
+func SetProviderAndWait(provider FeatureProvider) error {
+	return api.setProvider(provider, false)
 }
 
 // SetNamedProvider sets a provider mapped to the given Client name. Provider initialization is asynchronous and
 // status can be checked from provider status
 func SetNamedProvider(clientName string, provider FeatureProvider) error {
-	return api.setNamedProvider(clientName, provider)
+	return api.setNamedProvider(clientName, provider, true)
+}
+
+// SetNamedProviderAndWait sets a provider mapped to the given Client name and waits for its initialization.
+func SetNamedProviderAndWait(clientName string, provider FeatureProvider) error {
+	return api.setNamedProvider(clientName, provider, false)
 }
 
 // SetEvaluationContext sets the global evaluation context.


### PR DESCRIPTION
## This PR

- Add `SetProviderAndWait` & `SetNamedProviderAndWait` with blocking provider mutators
- Improve non-eventing provider registration by emitting ready event : This can be considered as a fix as this is defined in spec but was missing in the implementation [^1]

> The provider MAY define a status field/accessor which indicates the readiness of the provider, with possible values NOT_READY, READY, STALE, or ERROR.

> Providers without this field can be assumed to be ready immediately.

### Related Issues

Fixes #240

### How to test

Tests were added to cover new APIs and old tests were updated to handle readiness emitted for non eventing providers 

[^1]: https://openfeature.dev/specification/sections/providers#requirement-242

