### PR TITLE
chore: require go 1.21

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 env:
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "~1.20"
+  DEFAULT_GO_VERSION: "~1.21"
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,9 +5,7 @@ on:
     branches:
       - main
   pull_request:
-env:
-  # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "~1.21"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -15,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.DEFAULT_GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup Environment
@@ -39,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.DEFAULT_GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,12 +10,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - name: Setup Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
@@ -34,14 +34,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - name: Setup Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,8 +6,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "~1.21"
 
 jobs:
   release-please:
@@ -37,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.DEFAULT_GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Install cyclonedx-gomod
         uses: CycloneDX/gh-gomod-generate-sbom@v2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: "~1.20"
+  DEFAULT_GO_VERSION: "~1.21"
 
 jobs:
   release-please:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-feature/go-sdk
 
-go 1.20
+go 1.21
 
 require (
 	github.com/cucumber/godog v0.14.1


### PR DESCRIPTION
Require go 1.21.

1.20 has long been EOL: https://endoflife.date/go

This is consistent with our guidelines on runtime support.