### PR TITLE
chore: use correct term "domain" instead of name/clientName in code

### DIFF
--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -126,16 +126,16 @@ func (e *eventExecutor) RemoveHandler(t EventType, c EventCallback) {
 }
 
 // AddClientHandler registers a client level handler
-func (e *eventExecutor) AddClientHandler(clientDomain string, t EventType, c EventCallback) {
+func (e *eventExecutor) AddClientHandler(domain string, t EventType, c EventCallback) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	_, ok := e.scopedRegistry[clientDomain]
+	_, ok := e.scopedRegistry[domain]
 	if !ok {
-		e.scopedRegistry[clientDomain] = newScopedCallback(clientDomain)
+		e.scopedRegistry[domain] = newScopedCallback(domain)
 	}
 
-	registry := e.scopedRegistry[clientDomain]
+	registry := e.scopedRegistry[domain]
 
 	if registry.callbacks[t] == nil {
 		registry.callbacks[t] = []EventCallback{c}
@@ -143,27 +143,27 @@ func (e *eventExecutor) AddClientHandler(clientDomain string, t EventType, c Eve
 		registry.callbacks[t] = append(registry.callbacks[t], c)
 	}
 
-	reference, ok := e.namedProviderReference[clientDomain]
+	reference, ok := e.namedProviderReference[domain]
 	if !ok {
 		// fallback to default
 		reference = e.defaultProviderReference
 	}
 
-	e.emitOnRegistration(clientDomain, reference, t, c)
+	e.emitOnRegistration(domain, reference, t, c)
 }
 
 // RemoveClientHandler removes a client level handler
-func (e *eventExecutor) RemoveClientHandler(name string, t EventType, c EventCallback) {
+func (e *eventExecutor) RemoveClientHandler(domain string, t EventType, c EventCallback) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	_, ok := e.scopedRegistry[name]
+	_, ok := e.scopedRegistry[domain]
 	if !ok {
 		// nothing to remove
 		return
 	}
 
-	entrySlice := e.scopedRegistry[name].callbacks[t]
+	entrySlice := e.scopedRegistry[domain].callbacks[t]
 	if entrySlice == nil {
 		// nothing to remove
 		return
@@ -175,7 +175,7 @@ func (e *eventExecutor) RemoveClientHandler(name string, t EventType, c EventCal
 		}
 	}
 
-	e.scopedRegistry[name].callbacks[t] = entrySlice
+	e.scopedRegistry[domain].callbacks[t] = entrySlice
 }
 
 func (e *eventExecutor) GetAPIRegistry() map[EventType][]EventCallback {
@@ -188,8 +188,8 @@ func (e *eventExecutor) GetClientRegistry(client string) scopedCallback {
 
 // emitOnRegistration fulfils the spec requirement to fire events if the
 // event type and the state of the associated provider are compatible.
-func (e *eventExecutor) emitOnRegistration(clientDomain string, providerReference providerReference, eventType EventType, callback EventCallback) {
-	state, ok := e.states.Load(clientDomain)
+func (e *eventExecutor) emitOnRegistration(domain string, providerReference providerReference, eventType EventType, callback EventCallback) {
+	state, ok := e.states.Load(domain)
 	if !ok {
 		return
 	}
@@ -340,14 +340,14 @@ func (e *eventExecutor) triggerEvent(event Event, handler FeatureProvider) {
 	}
 
 	// then run client handlers
-	for name, reference := range e.namedProviderReference {
+	for domain, reference := range e.namedProviderReference {
 		if !reflect.DeepEqual(reference.featureProvider, handler) {
 			// unassociated client, continue to next
 			continue
 		}
 
-		e.states.Store(name, stateFromEvent(event))
-		for _, c := range e.scopedRegistry[name].callbacks[event.EventType] {
+		e.states.Store(domain, stateFromEvent(event))
+		for _, c := range e.scopedRegistry[domain].callbacks[event.EventType] {
 			e.executeHandler(*c, event)
 		}
 	}
@@ -359,8 +359,8 @@ func (e *eventExecutor) triggerEvent(event Event, handler FeatureProvider) {
 	// handling the default provider
 	e.states.Store(defaultClient, stateFromEvent(event))
 	// invoke default provider bound (no provider associated) handlers by filtering
-	for clientName, registry := range e.scopedRegistry {
-		if _, ok := e.namedProviderReference[clientName]; ok {
+	for domain, registry := range e.scopedRegistry {
+		if _, ok := e.namedProviderReference[domain]; ok {
 			// association exist, skip and check next
 			continue
 		}

--- a/openfeature/openfeature.go
+++ b/openfeature/openfeature.go
@@ -43,14 +43,14 @@ func ProviderMetadata() Metadata {
 
 // SetNamedProvider sets a provider mapped to the given Client domain. Provider initialization is asynchronous and
 // status can be checked from provider status
-func SetNamedProvider(clientDomain string, provider FeatureProvider) error {
-	return api.SetNamedProvider(clientDomain, provider, true)
+func SetNamedProvider(domain string, provider FeatureProvider) error {
+	return api.SetNamedProvider(domain, provider, true)
 }
 
 // SetNamedProviderAndWait sets a provider mapped to the given Client domain and waits for its initialization.
 // Returns an error if initialization cause error
-func SetNamedProviderAndWait(clientDomain string, provider FeatureProvider) error {
-	return api.SetNamedProvider(clientDomain, provider, false)
+func SetNamedProviderAndWait(domain string, provider FeatureProvider) error {
+	return api.SetNamedProvider(domain, provider, false)
 }
 
 // NamedProviderMetadata returns the named provider's Metadata

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -526,14 +526,14 @@ func TestRequirement_1_1_6(t *testing.T) {
 		}
 	})
 
-	t.Run("client from api level - no name", func(t *testing.T) {
+	t.Run("client from api level - no domain", func(t *testing.T) {
 		client := api.GetClient()
 		if client == nil {
 			t.Errorf("expected an IClient instance, but got invalid")
 		}
 	})
 
-	t.Run("client from api level - with name", func(t *testing.T) {
+	t.Run("client from api level - with domain", func(t *testing.T) {
 		client := api.GetNamedClient("test-client")
 		if client == nil {
 			t.Errorf("expected an IClient instance, but got invalid")

--- a/pkg/openfeature/client.go
+++ b/pkg/openfeature/client.go
@@ -20,8 +20,8 @@ type ClientMetadata = openfeature.ClientMetadata
 //
 // Deprecated: use
 // github.com/open-feature/go-sdk/openfeature.NewClientMetadata, instead.
-func NewClientMetadata(name string) ClientMetadata {
-	return openfeature.NewClientMetadata(name)
+func NewClientMetadata(domain string) ClientMetadata {
+	return openfeature.NewClientMetadata(domain)
 }
 
 // Client implements the behaviour required of an openfeature client
@@ -29,12 +29,12 @@ func NewClientMetadata(name string) ClientMetadata {
 // Deprecated: use github.com/open-feature/go-sdk/openfeature.Client, instead.
 type Client = openfeature.Client
 
-// NewClient returns a new Client. Name is a unique identifier for this client
+// NewClient returns a new Client. Domain is a unique identifier for this client
 //
 // Deprecated: use github.com/open-feature/go-sdk/openfeature.NewClient,
 // instead.
-func NewClient(name string) *Client {
-	return openfeature.NewClient(name)
+func NewClient(domain string) *Client {
+	return openfeature.NewClient(domain)
 }
 
 // Type represents the type of a flag

--- a/pkg/openfeature/openfeature.go
+++ b/pkg/openfeature/openfeature.go
@@ -20,8 +20,8 @@ func SetProvider(provider FeatureProvider) error {
 //
 // Deprecated: use github.com/open-feature/go-sdk/openfeature.SetNamedProvider,
 // instead.
-func SetNamedProvider(clientName string, provider FeatureProvider) error {
-	return openfeature.SetNamedProvider(clientName, provider)
+func SetNamedProvider(domain string, provider FeatureProvider) error {
+	return openfeature.SetNamedProvider(domain, provider)
 }
 
 // SetEvaluationContext sets the global evaluation context.


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This PR ensures consistent usage of the term "domain" throughout the codebase, replacing instances of "name," "clientName," and similar terms.



