### PR TITLE
chore: fix coverage uploads to Codecov

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,13 +54,24 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
       - name: Run unit tests
-        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+        run: go test -race -short -coverpkg=./... -coverprofile=coverage-unit.out -covermode=atomic ./...
       - name: Run e2e tests
-        run: go test -race --coverprofile=coverage.out -covermode=atomic ./e2e/... 
-      - name: Upload coverage to Codecov
+        run: go test -race -coverpkg=./... -coverprofile=coverage-e2e.out -covermode=atomic ./e2e/...
+      - name: Upload coverage to Codecov (unit)
         uses: codecov/codecov-action@v4.6.0
         with:
-          name: Code Coverage for GO SDK
+          name: Code Coverage for GO SDK (unit)
+          files: ./coverage-unit.out
+          flags: unit
+          fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
+      - name: Upload coverage to Codecov (e2e)
+        uses: codecov/codecov-action@v4.6.0
+        with:
+          name: Code Coverage for GO SDK (e2e)
+          files: ./coverage-e2e.out
+          flags: e2e
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes publishing test coverage results to Codecov.
The coverage results are now saved in two separate files, `coverage-unit.out` and `coverage-e2e.out`, preventing any overwrites during the execution of the two test suites. Additionally, each result is uploaded to Codecov separately, with distinct flags to logically differentiate them.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->
fixes  #304


### How to test
<!-- if applicable, add testing instructions under this section -->
https://app.codecov.io/github/open-feature/go-sdk/tree/warber%2Fgo-sdk%3Atest%2Ffix-codecov-upload/openfeature
