### PR TITLE
docs: add PR title and DCO rules to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Signed-off-by: John Doe <jd@example.org>
 
 This is easy to add by using the [`-s`/`--signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) flag to `git commit`.
 
-More  info is available in the [OpenFeature community docs](https://openfeature.dev/community/technical-guidelines/#developer-certificate-of-origin).
+More info is available in the [OpenFeature community docs](https://openfeature.dev/community/technical-guidelines/#developer-certificate-of-origin).
 
 ### Releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,21 @@ The full list of available types is:
  - `chore`: Other changes that don't modify src or test files
  - `revert`: Reverts a previous commit
 
+#### Developer Certificate of Origin
+
+The [Developer Certificate of Origin (DCO)](https://developercertificate.org/) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.
+To sign off that they adhere to these requirements, all commits need to have a `Signed-off-by` line, like:
+
+```
+fix: solve all the problems
+
+Signed-off-by: John Doe <jd@example.org>
+```
+
+This is easy to add by using the [`-s`/`--signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) flag to `git commit`.
+
+More  info is available in the [OpenFeature community docs](https://openfeature.dev/community/technical-guidelines/#developer-certificate-of-origin).
+
 ### Releases
 
 This repo uses Release Please to release packages. Release Please set up a running PR that tracks all changes for the library components, and maintains the versions according to conventional commits, generated when PRs are merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,25 @@ go test -fuzz=FuzzBooleanEvaluation ./e2e/evaluation_fuzz_test.go
 ```
 substituting the name of the fuzz as appropriate.
 
+### Opening a Pull Request
+
+#### Titles
+
+We require PR titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/), meaning all titles should begin with a specifier for the type of change being made, followed by a colon, like `feat: add support for boolean flags` or `perf: improve flag evaluation times by removing time.Sleep`.
+
+The full list of available types is:
+ - `feat`: A new feature
+ - `fix`: A bug fix
+ - `docs`: Documentation only changes
+ - `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+ - `refactor`: A code change that neither fixes a bug nor adds a feature
+ - `perf`: A code change that improves performance
+ - `test`: Adding missing tests or correcting existing tests
+ - `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+ - `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+ - `chore`: Other changes that don't modify src or test files
+ - `revert`: Reverts a previous commit
+
 ### Releases
 
 This repo uses Release Please to release packages. Release Please set up a running PR that tracks all changes for the library components, and maintains the versions according to conventional commits, generated when PRs are merged.


### PR DESCRIPTION
This PR adds the commit convention to the CONTRIBUTING docs. This caught me out on https://github.com/open-feature/go-sdk/pull/320, hopefully this helps the next person!
