### PR TITLE
ci: updated goreleaser-action to v6 with updates to use goreleaser v2

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,8 +43,10 @@ jobs:
           version: v1.3.0
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          args: release --rm-dist
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --skip=publish --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- updates `goreleaser-action` from `v5` to `v6`
- `v6` utilizes `v2` of `goreleaser` updated the parameters of the action to specify the `distribution` and `version`
- update the `args` to use the new argument of `--clean` instead of `--rm-rf`

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #324

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

