### PR TITLE
feat: add evaluation details to finally hook

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -710,7 +710,7 @@ func (c *Client) evaluate(
 	}
 
 	defer func() {
-		c.finallyHooks(ctx, hookCtx, providerInvocationClientApiHooks, options)
+		c.finallyHooks(ctx, hookCtx, providerInvocationClientApiHooks, evalDetails, options)
 	}()
 
         // bypass short-circuit logic for the Noop provider; it is essentially stateless and a "special case"
@@ -828,9 +828,9 @@ func (c *Client) errorHooks(ctx context.Context, hookCtx HookContext, hooks []Ho
 	}
 }
 
-func (c *Client) finallyHooks(ctx context.Context, hookCtx HookContext, hooks []Hook, options EvaluationOptions) {
+func (c *Client) finallyHooks(ctx context.Context, hookCtx HookContext, hooks []Hook, evalDetails InterfaceEvaluationDetails, options EvaluationOptions) {
 	for _, hook := range hooks {
-		hook.Finally(ctx, hookCtx, options.hookHints)
+		hook.Finally(ctx, hookCtx,evalDetails, options.hookHints)
 	}
 }
 

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -1314,7 +1314,7 @@ func TestRequirement_1_7_6(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockHook := NewMockHook(ctrl)
 	mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), ProviderNotReadyError, gomock.Any())
-	mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+	mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 	notReadyEventingProvider := struct {
 		FeatureProvider
@@ -1377,7 +1377,7 @@ func TestRequirement_1_7_7(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockHook := NewMockHook(ctrl)
 	mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), ProviderFatalError, gomock.Any())
-	mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+	mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 	client := GetApiInstance().GetNamedClient(t.Name())
 	client.AddHooks(mockHook)

--- a/openfeature/hooks.go
+++ b/openfeature/hooks.go
@@ -9,7 +9,7 @@ type Hook interface {
 	Before(ctx context.Context, hookContext HookContext, hookHints HookHints) (*EvaluationContext, error)
 	After(ctx context.Context, hookContext HookContext, flagEvaluationDetails InterfaceEvaluationDetails, hookHints HookHints) error
 	Error(ctx context.Context, hookContext HookContext, err error, hookHints HookHints)
-	Finally(ctx context.Context, hookContext HookContext, hookHints HookHints)
+	Finally(ctx context.Context, hookContext HookContext, flagEvaluationDetails InterfaceEvaluationDetails, hookHints HookHints)
 }
 
 // HookHints contains a map of hints for hooks
@@ -108,4 +108,4 @@ func (UnimplementedHook) After(context.Context, HookContext, InterfaceEvaluation
 	return nil
 }
 func (UnimplementedHook) Error(context.Context, HookContext, error, HookHints) {}
-func (UnimplementedHook) Finally(context.Context, HookContext, HookHints)      {}
+func (UnimplementedHook) Finally(context.Context, HookContext, InterfaceEvaluationDetails, HookHints)      {}

--- a/openfeature/hooks/logging_hook.go
+++ b/openfeature/hooks/logging_hook.go
@@ -91,6 +91,6 @@ func (h *LoggingHook) Error(ctx context.Context, hookContext of.HookContext, err
 	h.logger.Error("Error stage", args...)
 }
 
-func (h *LoggingHook) Finally(ctx context.Context, hCtx of.HookContext, hint of.HookHints) {
+func (h *LoggingHook) Finally(ctx context.Context, hCtx of.HookContext,flagEvaluationDetails of.InterfaceEvaluationDetails, hint of.HookHints) {
 
 }

--- a/openfeature/hooks_mock_test.go
+++ b/openfeature/hooks_mock_test.go
@@ -76,13 +76,13 @@ func (mr *MockHookMockRecorder) Error(ctx, hookContext, err, hookHints interface
 }
 
 // Finally mocks base method.
-func (m *MockHook) Finally(ctx context.Context, hookContext HookContext, hookHints HookHints) {
+func (m *MockHook) Finally(ctx context.Context, hookContext HookContext, flagEvaluationDetails InterfaceEvaluationDetails, hookHints HookHints) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Finally", ctx, hookContext, hookHints)
 }
 
 // Finally indicates an expected call of Finally.
-func (mr *MockHookMockRecorder) Finally(ctx, hookContext, hookHints interface{}) *gomock.Call {
+func (mr *MockHookMockRecorder) Finally(ctx, hookContext, flagEvaluationDetails, hookHints interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finally", reflect.TypeOf((*MockHook)(nil).Finally), ctx, hookContext, hookHints)
 }

--- a/openfeature/hooks_test.go
+++ b/openfeature/hooks_test.go
@@ -174,7 +174,7 @@ func TestRequirement_4_3_2(t *testing.T) {
 		mockProvider.EXPECT().StringEvaluation(gomock.Any(), flagKey, defaultValue, flatCtx).
 			After(mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()))
 		mockHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		_, err = GetApiInstance().GetNamedClient(t.Name()).StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook))
 		if err != nil {
@@ -244,9 +244,9 @@ func TestRequirement_4_3_3(t *testing.T) {
 	mockHook2.EXPECT().Before(gomock.Any(), hook2Ctx, gomock.Any())
 
 	mockHook1.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	mockHook1.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+	mockHook1.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	mockHook2.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	mockHook2.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+	mockHook2.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 	_, err = client.StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook1, mockHook2))
 	if err != nil {
@@ -321,7 +321,7 @@ func TestRequirement_4_3_4(t *testing.T) {
 	}
 	mockProvider.EXPECT().StringEvaluation(gomock.Any(), flagKey, defaultValue, flattenContext(expectedMergedContext))
 	mockHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+	mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 	_, err = client.StringValueDetails(context.Background(), flagKey, defaultValue, invEvalCtx, WithHooks(mockHook))
 	if err != nil {
@@ -357,7 +357,7 @@ func TestRequirement_4_3_5(t *testing.T) {
 		// assert that the After hooks are executed after the flag evaluation
 		mockHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			After(mockProvider.EXPECT().StringEvaluation(gomock.Any(), flagKey, defaultValue, flatCtx))
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		_, err = GetApiInstance().GetNamedClient(t.Name()).StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook))
 		if err != nil {
@@ -407,7 +407,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 		// assert that the Error hooks are executed after the failed Before hooks
 		mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			After(mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("forced")))
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		_, err = GetApiInstance().GetNamedClient(t.Name()).StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook))
 		if err == nil {
@@ -440,7 +440,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 						},
 					}),
 			)
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		_, err = GetApiInstance().GetNamedClient(t.Name()).StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook))
 		if err == nil {
@@ -467,7 +467,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 		// assert that the Error hooks are executed after the failed After hooks
 		mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			After(mockHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("forced")))
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		_, err = GetApiInstance().GetNamedClient(t.Name()).StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook))
 		if err == nil {
@@ -514,7 +514,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 		mockProvider.EXPECT().Hooks().AnyTimes()
 
 		// assert that the Finally hook runs after the Before & After stages
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			After(mockHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())).
 			After(mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()))
 		mockProvider.EXPECT().StringEvaluation(context.Background(), flagKey, defaultValue, flatCtx)
@@ -541,7 +541,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 
 		mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("forced"))
 		// assert that the Finally hook runs after the Error stage
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			After(mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()))
 
 		_, err = GetApiInstance().GetNamedClient(t.Name()).StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook))
@@ -554,7 +554,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 		mockHook := NewMockHook(ctrl)
 
 		type requirement interface {
-			Finally(ctx context.Context, hookContext HookContext, hookHints HookHints)
+			Finally(ctx context.Context, hookContext HookContext, flagEvaluationDetails InterfaceEvaluationDetails, hookHints HookHints)
 		}
 
 		var hookI interface{} = mockHook
@@ -673,10 +673,10 @@ func TestRequirement_4_4_2(t *testing.T) {
 			After(mockProviderHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()))
 
 		// finally: Invocation, Client, API
-		mockAPIHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any()).
-			After(mockClientHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())).
-			After(mockInvocationHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())).
-			After(mockProviderHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any()))
+		mockAPIHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			After(mockClientHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())).
+			After(mockInvocationHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())).
+			After(mockProviderHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()))
 
 		mockProvider.EXPECT().StringEvaluation(context.Background(), flagKey, defaultValue, flatCtx)
 
@@ -717,10 +717,10 @@ func TestRequirement_4_4_2(t *testing.T) {
 			After(mockInvocationHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())).
 			After(mockProviderHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()))
 
-		mockProviderHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
-		mockInvocationHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
-		mockClientHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
-		mockAPIHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+		mockProviderHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		mockInvocationHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		mockClientHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		mockAPIHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		_, err = client.StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockInvocationHook))
 		if err == nil {
@@ -779,9 +779,9 @@ func TestRequirement_4_4_6(t *testing.T) {
 			mockHook1.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("forced"))
 			// the lack of mockHook2.EXPECT().Before() asserts that remaining hooks aren't invoked after an error
 			mockHook1.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-			mockHook1.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+			mockHook1.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			mockHook2.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-			mockHook2.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+			mockHook2.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 			_, err = client.StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook1, mockHook2))
 			if err == nil {
@@ -814,9 +814,9 @@ func TestRequirement_4_4_6(t *testing.T) {
 			mockHook1.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("forced"))
 			// the lack of mockHook2.EXPECT().After() asserts that remaining hooks aren't invoked after an error
 			mockHook1.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-			mockHook1.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+			mockHook1.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			mockHook2.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-			mockHook2.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+			mockHook2.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 			mockProvider.EXPECT().StringEvaluation(context.Background(), flagKey, defaultValue, flatCtx)
 
@@ -850,7 +850,7 @@ func TestRequirement_4_4_7(t *testing.T) {
 
 	mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("forced"))
 	mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-	mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+	mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 	res, err := GetApiInstance().GetNamedClient(t.Name()).StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook))
 	if err == nil {
@@ -900,7 +900,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 
 		mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), hookHints)
 		mockHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), hookHints)
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), hookHints)
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), hookHints)
 
 		mockProvider.EXPECT().StringEvaluation(context.Background(), flagKey, defaultValue, flatCtx)
 
@@ -933,7 +933,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 
 		mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("forced"))
 		mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), hookHints)
-		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any())
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		_, err = client.StringValueDetails(context.Background(), flagKey, defaultValue, evalCtx, WithHooks(mockHook), WithHookHints(hookHints))
 		if err == nil {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds `evaluation details` to `finally` hook stage
- utilized `InterfaceEvaluationDetails` similar to the `After` method of the hook

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #327 

### Notes
<!-- any additional notes for this PR -->

This breaks the signature of the finally stages based on [this spec enhancement](https://github.com/open-feature/spec/pull/280). It is not considered a breaking change to the SDK because hooks are marked as experimental in the spec, and the change has no impact on known hooks.

```suggestion
- Finally(ctx context.Context, hookContext HookContext, hookHints HookHints)
+ Finally(ctx context.Context, hookContext HookContext, flagEvaluationDetails InterfaceEvaluationDetails, hookHints HookHints)
```

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
Update the `go-sdk-contrib` repo, with a quick search the few places finally is being used that I saw.
- [go-feature-flag data](https://github.com/open-feature/go-sdk-contrib/blob/4b04d0ee71a0b7faae3c156a655e1eed26381237/providers/go-feature-flag/pkg/hook/data_collector_hook.go#L61)
- [go-feature-flag evaluation](https://github.com/open-feature/go-sdk-contrib/blob/4b04d0ee71a0b7faae3c156a655e1eed26381237/providers/go-feature-flag/pkg/hook/evaluation_enrichment_hook.go#L43)
- [open-telemetry metrics](https://github.com/open-feature/go-sdk-contrib/blob/4b04d0ee71a0b7faae3c156a655e1eed26381237/hooks/open-telemetry/pkg/metrics.go#L125)
- [open-telemetry metrics-test](https://github.com/open-feature/go-sdk-contrib/blob/4b04d0ee71a0b7faae3c156a655e1eed26381237/hooks/open-telemetry/pkg/metrics_test.go#L183)

### How to test
<!-- if applicable, add testing instructions under this section -->

- Running local unit tests passed again with change to interface.