### PR TITLE
test: fix tests - add missing cleanup and wait.

### DIFF
--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -721,6 +721,7 @@ func TestDefaultClientUsage(t *testing.T) {
 }
 
 func TestLateBindingOfDefaultProvider(t *testing.T) {
+	defer t.Cleanup(initSingleton)
 	// we are expecting
 	expectedResultUnboundProvider := "default-value-from-unbound-provider"
 	expectedResultFromLateDefaultProvider := "value-from-late-default-provider"

--- a/openfeature/testing/testprovider_test.go
+++ b/openfeature/testing/testprovider_test.go
@@ -12,7 +12,7 @@ func TestParallelSingletonUsage(t *testing.T) {
 	t.Parallel()
 
 	testProvider := NewTestProvider()
-	err := openfeature.GetApiInstance().SetProvider(testProvider)
+	err := openfeature.GetApiInstance().SetProviderAndWait(testProvider)
 	if err != nil {
 		t.Errorf("unable to set provider")
 	}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Fix tests: add missing cleanup and wait.

Missing cleanup caused test failures if the tests are executed in a different order.
Missing wait caused issues when the provider wasn't initializes before the test executed.


