### PR TITLE
chore(lint): fix Makefile lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,4 @@ test:
 e2e-test:
 	 git submodule update --init --recursive && go test -race -cover ./e2e/...
 lint:
-	go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
-	${GOPATH}/bin/golangci-lint run --deadline=3m --timeout=3m ./... # Run linters
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --timeout=3m ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-feature/go-sdk
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/cucumber/godog v0.15.0


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->


Upgrade golangci-lint to the latest version and simplify the lint target by using `go run` instead of `go install`. Also remove the --deadline flag as it was renamed to --timeout.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->
fix #342 

### Notes
<!-- any additional notes for this PR -->
golangci-lint changelog: https://golangci-lint.run/product/changelog/

### How to test
<!-- if applicable, add testing instructions under this section -->
```sh
make lint
```

