### PR TITLE
docs: deprecate identifiers correctly

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -24,7 +24,8 @@ func NewClientMetadata(domain string) ClientMetadata {
 }
 
 // Name returns the client's domain name
-// Deprecated: Name() exists for historical compatibility, use Domain() instead.
+//
+// Deprecated: Name() exists for historical compatibility, use [ClientMetadata.Domain] instead.
 func (cm ClientMetadata) Name() string {
 	return cm.domain
 }
@@ -71,8 +72,9 @@ func (c *Client) State() State {
 	return c.clientEventing.State(c.domain)
 }
 
-// Deprecated
 // WithLogger sets the logger of the client
+//
+// Deprecated: use [github.com/open-feature/go-sdk/openfeature/hooks.LoggingHook] instead.
 func (c *Client) WithLogger(l logr.Logger) *Client {
 	c.mx.Lock()
 	defer c.mx.Unlock()

--- a/openfeature/interfaces.go
+++ b/openfeature/interfaces.go
@@ -2,6 +2,7 @@ package openfeature
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 )
 
@@ -67,7 +68,7 @@ type evaluationImpl interface {
 	GetNamedProviders() map[string]FeatureProvider
 	GetHooks() []Hook
 
-	// Deprecated
+	// Deprecated: use [github.com/open-feature/go-sdk/openfeature/hooks.LoggingHook] instead.
 	SetLogger(l logr.Logger)
 
 	ForEvaluation(clientName string) (FeatureProvider, []Hook, EvaluationContext)

--- a/openfeature/openfeature.go
+++ b/openfeature/openfeature.go
@@ -3,8 +3,10 @@ package openfeature
 import "github.com/go-logr/logr"
 
 // api is the global evaluationImpl implementation. This is a singleton and there can only be one instance.
-var api evaluationImpl
-var eventing eventingImpl
+var (
+	api      evaluationImpl
+	eventing eventingImpl
+)
 
 // init initializes the OpenFeature evaluation API
 func init() {
@@ -12,7 +14,7 @@ func init() {
 }
 
 func initSingleton() {
-	var exec = newEventExecutor()
+	exec := newEventExecutor()
 	eventing = exec
 
 	api = newEvaluationAPI(exec)
@@ -63,8 +65,9 @@ func SetEvaluationContext(evalCtx EvaluationContext) {
 	api.SetEvaluationContext(evalCtx)
 }
 
-// Deprecated
 // SetLogger sets the global Logger.
+//
+// Deprecated: use [github.com/open-feature/go-sdk/openfeature/hooks.LoggingHook] instead.
 func SetLogger(l logr.Logger) {
 }
 

--- a/openfeature/openfeature_api.go
+++ b/openfeature/openfeature_api.go
@@ -112,9 +112,8 @@ func (api *evaluationAPI) SetEvaluationContext(apiCtx EvaluationContext) {
 	api.apiCtx = apiCtx
 }
 
-// Deprecated
+// Deprecated: use [github.com/open-feature/go-sdk/openfeature/hooks.LoggingHook] instead.
 func (api *evaluationAPI) SetLogger(l logr.Logger) {
-
 }
 
 func (api *evaluationAPI) AddHooks(hooks ...Hook) {
@@ -248,7 +247,7 @@ func (api *evaluationAPI) initNewAndShutdownOld(clientName string, newProvider F
 // initializer is a helper to execute provider initialization and generate appropriate event for the initialization
 // It also returns an error if the initialization resulted in an error
 func initializer(provider FeatureProvider, apiCtx EvaluationContext) (Event, error) {
-	var event = Event{
+	event := Event{
 		ProviderName: provider.Metadata().Name,
 		EventType:    ProviderReady,
 		ProviderEventDetails: ProviderEventDetails{


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
Correctly deprecate identifiers so that the pkgsite documentation hides the deprecated identifiers. Also use Go doc comment "doc links" to refer to exported identifiers.
https://tip.golang.org/doc/comment

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #346 

### Notes
<!-- any additional notes for this PR -->
You may see a few additional formatting changes that were made because I have my editor setup to run gofumpt on save.


### How to test
<!-- if applicable, add testing instructions under this section -->
```sh
make docs
```
