### PR TITLE
refactor: simplify and improve logging hook

### DIFF
--- a/openfeature/hooks/logging_hook.go
+++ b/openfeature/hooks/logging_hook.go
@@ -17,6 +17,7 @@ const (
 	REASON_KEY             = "reason"
 	VARIANT_KEY            = "variant"
 	VALUE_KEY              = "value"
+	STAGE_KEY              = "stage"
 )
 
 // LoggingHook is a [of.Hook] that logs the flag evaluation lifecycle.
@@ -64,6 +65,7 @@ func (h *LoggingHook) buildArgs(hookContext of.HookContext) []slog.Attr {
 
 func (h *LoggingHook) Before(ctx context.Context, hookContext of.HookContext, hookHints of.HookHints) (*of.EvaluationContext, error) {
 	args := h.buildArgs(hookContext)
+	args = append(args, slog.String(STAGE_KEY, "before"))
 	h.logger.LogAttrs(ctx, slog.LevelDebug, "Before stage", args...)
 	return nil, nil
 }
@@ -76,6 +78,7 @@ func (h *LoggingHook) After(ctx context.Context, hookContext of.HookContext,
 		slog.String(REASON_KEY, string(flagEvaluationDetails.Reason)),
 		slog.String(VARIANT_KEY, flagEvaluationDetails.Variant),
 		slog.Any(VALUE_KEY, flagEvaluationDetails.Value),
+		slog.String(STAGE_KEY, "after"),
 	)
 	h.logger.LogAttrs(ctx, slog.LevelDebug, "After stage", args...)
 	return nil
@@ -83,7 +86,10 @@ func (h *LoggingHook) After(ctx context.Context, hookContext of.HookContext,
 
 func (h *LoggingHook) Error(ctx context.Context, hookContext of.HookContext, err error, hookHints of.HookHints) {
 	args := h.buildArgs(hookContext)
-	args = append(args, slog.Any(ERROR_MESSAGE_KEY, err))
+	args = append(args,
+		slog.Any(ERROR_MESSAGE_KEY, err),
+		slog.String(STAGE_KEY, "error"),
+	)
 	h.logger.LogAttrs(ctx, slog.LevelError, "Error stage", args...)
 }
 

--- a/openfeature/hooks/logging_hook.go
+++ b/openfeature/hooks/logging_hook.go
@@ -19,15 +19,19 @@ const (
 	VALUE_KEY              = "value"
 )
 
+// LoggingHook is a [of.Hook] that logs the flag evaluation lifecycle.
 type LoggingHook struct {
 	includeEvaluationContext bool
 	logger                   *slog.Logger
 }
 
+// NewLoggingHook returns a new [LoggingHook] with the default logger.
+// To provide a custom logger, use [NewCustomLoggingHook].
 func NewLoggingHook(includeEvaluationContext bool) (*LoggingHook, error) {
 	return NewCustomLoggingHook(includeEvaluationContext, slog.Default())
 }
 
+// NewCustomLoggingHook returns a new [LoggingHook] with the provided logger.
 func NewCustomLoggingHook(includeEvaluationContext bool, logger *slog.Logger) (*LoggingHook, error) {
 	return &LoggingHook{
 		logger:                   logger,

--- a/openfeature/hooks/logging_hook_test.go
+++ b/openfeature/hooks/logging_hook_test.go
@@ -54,7 +54,7 @@ func TestLoggingHookHandlesNilLoggerGracefully(t *testing.T) {
 }
 
 func TestLoggingHookLogsMessagesAsExpected(t *testing.T) {
-	var buf *bytes.Buffer = new(bytes.Buffer)
+	buf := new(bytes.Buffer)
 	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
 	logger := slog.New(handler)
 

--- a/openfeature/hooks/logging_hook_test.go
+++ b/openfeature/hooks/logging_hook_test.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"testing"
-
-	"log/slog"
 
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
@@ -128,15 +127,17 @@ func testLoggingHookLogsMessagesAsExpected(hook LoggingHook, logger *slog.Logger
 
 		ms := prepareOutput(buf, t)
 
-		var expected = map[string]map[string]any{
+		expected := map[string]map[string]any{
 			"Before stage": {
 				"provider_name": "InMemoryProvider",
 				"domain":        "test-app",
+				"stage":         "before",
 			},
 			"After stage": {
 				"provider_name": "InMemoryProvider",
 				"domain":        "test-app",
 				"flag_key":      "boolFlag",
+				"stage":         "after",
 			},
 		}
 
@@ -164,15 +165,17 @@ func testLoggingHookLogsMessagesAsExpected(hook LoggingHook, logger *slog.Logger
 
 		ms := prepareOutput(buf, t)
 
-		var expected = map[string]map[string]any{
+		expected := map[string]map[string]any{
 			"Before stage": {
 				"provider_name": "InMemoryProvider",
 				"domain":        "test-app",
+				"stage":         "before",
 			},
 			"Error stage": {
 				"provider_name": "InMemoryProvider",
 				"domain":        "test-app",
 				"flag_key":      "non-existing",
+				"stage":         "error",
 			},
 		}
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- add go doc comments
- add a `stage` key to the logs as per [the spec](https://openfeature.dev/specification/appendix-a#logging-hook)
- ensure LoggingHook method receivers are all named `h` (the `buildArgs` method had a receiver named `l`)
- use consistent parameter names for the Before, After, Error, and Finally methods
- simplify the `buildArgs` method by removing the error return parameter
- use [slog.Attr](https://pkg.go.dev/log/slog#Attr) instead of `interface{}` types to log attributes
- the above allows the use of [Logger.LogAttrs](https://pkg.go.dev/log/slog#Logger.LogAttrs), which is [the most efficient form of log output](https://pkg.go.dev/log/slog#Logger.LogAttrs:~:text=For%20the%20most%20efficient,ctx%2C%20%22hello%22%2C%20%22count%22%2C%203)
- as a consequence of the above, the logging performed by the logging hook is now context aware (the `ctx` parameter is passed to `Logger.LogAttrs`)

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

