### PR TITLE
style: replace usage of `interface{}` with `any`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If the flag management system you're using supports targeting, you can provide t
 ```go
 // set a value to the global context
 openfeature.SetEvaluationContext(openfeature.NewTargetlessEvaluationContext(
-    map[string]interface{}{
+    map[string]any{
         "region":  "us-east-1-iah-1a",
     },
 ))
@@ -136,7 +136,7 @@ openfeature.SetEvaluationContext(openfeature.NewTargetlessEvaluationContext(
 // set a value to the client context
 client := openfeature.NewClient("my-app")
 client.SetEvaluationContext(openfeature.NewTargetlessEvaluationContext(
-    map[string]interface{}{
+    map[string]any{
         "version":  "1.4.6",
     },
 ))
@@ -144,7 +144,7 @@ client.SetEvaluationContext(openfeature.NewTargetlessEvaluationContext(
 // set a value to the invocation context
 evalCtx := openfeature.NewEvaluationContext(
     "user-123",
-    map[string]interface{}{
+    map[string]any{
         "company": "Initech",
     },
 )
@@ -371,7 +371,7 @@ func (i MyFeatureProvider) IntEvaluation(ctx context.Context, flag string, defau
 }
 
 // ObjectEvaluation returns an object flag
-func (i MyFeatureProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue interface{}, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+func (i MyFeatureProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
   // code to evaluate object
 }
 

--- a/e2e/common_test.go
+++ b/e2e/common_test.go
@@ -7,7 +7,7 @@ import (
 
 // ctxFunction is a context based evaluation callback
 var ctxFunction = func(this memprovider.InMemoryFlag, evalCtx openfeature.FlattenedContext) (
-	interface{}, openfeature.ProviderResolutionDetail) {
+	any, openfeature.ProviderResolutionDetail) {
 
 	defaultValue := this.Variants[this.DefaultVariant]
 	defaultResolution := openfeature.ProviderResolutionDetail{
@@ -39,7 +39,7 @@ var memoryFlags = map[string]memprovider.InMemoryFlag{
 		Key:            "boolean-flag",
 		State:          memprovider.Enabled,
 		DefaultVariant: "on",
-		Variants: map[string]interface{}{
+		Variants: map[string]any{
 			"on":  true,
 			"off": false,
 		},
@@ -49,7 +49,7 @@ var memoryFlags = map[string]memprovider.InMemoryFlag{
 		Key:            "string-flag",
 		State:          memprovider.Enabled,
 		DefaultVariant: "greeting",
-		Variants: map[string]interface{}{
+		Variants: map[string]any{
 			"greeting": "hi",
 			"parting":  "bye",
 		},
@@ -59,7 +59,7 @@ var memoryFlags = map[string]memprovider.InMemoryFlag{
 		Key:            "integer-flag",
 		State:          memprovider.Enabled,
 		DefaultVariant: "ten",
-		Variants: map[string]interface{}{
+		Variants: map[string]any{
 			"one": 1,
 			"ten": 10,
 		},
@@ -69,7 +69,7 @@ var memoryFlags = map[string]memprovider.InMemoryFlag{
 		Key:            "float-flag",
 		State:          memprovider.Enabled,
 		DefaultVariant: "half",
-		Variants: map[string]interface{}{
+		Variants: map[string]any{
 			"tenth": 0.1,
 			"half":  0.5,
 		},
@@ -79,9 +79,9 @@ var memoryFlags = map[string]memprovider.InMemoryFlag{
 		Key:            "object-flag",
 		State:          memprovider.Enabled,
 		DefaultVariant: "template",
-		Variants: map[string]interface{}{
-			"empty": map[string]interface{}{},
-			"template": map[string]interface{}{
+		Variants: map[string]any{
+			"empty": map[string]any{},
+			"template": map[string]any{
 				"showImages":    true,
 				"title":         "Check out these pics!",
 				"imagesPerPage": 100,
@@ -93,7 +93,7 @@ var memoryFlags = map[string]memprovider.InMemoryFlag{
 		Key:            "wrong-flag",
 		State:          memprovider.Enabled,
 		DefaultVariant: "one",
-		Variants: map[string]interface{}{
+		Variants: map[string]any{
 			"one": "uno",
 			"two": "dos",
 		},
@@ -103,7 +103,7 @@ var memoryFlags = map[string]memprovider.InMemoryFlag{
 		Key:            "context-aware",
 		State:          memprovider.Enabled,
 		DefaultVariant: "external",
-		Variants: map[string]interface{}{
+		Variants: map[string]any{
 			"internal": "INTERNAL",
 			"external": "EXTERNAL",
 		},

--- a/e2e/evaluation_fuzz_test.go
+++ b/e2e/evaluation_fuzz_test.go
@@ -111,7 +111,7 @@ func FuzzObjectEvaluation(f *testing.F) {
 	f.Add("FoO", "true")
 	f.Add("FoO234", "-1.23")
 	f.Add("FoO2\b34", "1")
-	f.Fuzz(func(t *testing.T, flagKey string, defaultValue string) { // interface{} is not supported, using a string
+	f.Fuzz(func(t *testing.T, flagKey string, defaultValue string) { // any is not supported, using a string
 		res, err := client.ObjectValueDetails(context.Background(), flagKey, defaultValue, openfeature.EvaluationContext{})
 		if err != nil {
 			if res.ErrorCode == openfeature.FlagNotFoundCode {

--- a/e2e/evaluation_test.go
+++ b/e2e/evaluation_test.go
@@ -219,7 +219,7 @@ func anObjectFlagWithKeyIsEvaluatedWithANullDefaultValue(ctx context.Context, fl
 func theResolvedObjectValueShouldBeContainFieldsAndWithValuesAndRespectively(
 	ctx context.Context, field1, field2, field3, value1, value2 string, value3 int) error {
 
-	got, ok := ctx.Value(ctxStorageKey{}).(map[string]interface{})
+	got, ok := ctx.Value(ctxStorageKey{}).(map[string]any)
 	if !ok {
 		return errors.New("no flag resolution result")
 	}
@@ -454,7 +454,7 @@ func theResolvedObjectDetailsValueShouldBeContainFieldsAndWithValuesAndRespectiv
 		return err
 	}
 
-	content, ok := gotResDetail.Value.(map[string]interface{})
+	content, ok := gotResDetail.Value.(map[string]any)
 	if !ok {
 		return errors.New("unexpected value format")
 	}
@@ -516,7 +516,7 @@ func theVariantShouldBeAndTheReasonShouldBe(ctx context.Context, variant, reason
 func contextContainsKeysWithValues(
 	ctx context.Context, ctxKey1, ctxKey2, ctxKey3, ctxKey4, ctxValue1, ctxValue2 string, ctxValue3 int64, ctxValue4 string,
 ) (context.Context, error) {
-	evalCtx := openfeature.NewEvaluationContext("", map[string]interface{}{
+	evalCtx := openfeature.NewEvaluationContext("", map[string]any{
 		ctxKey1: boolOrString(ctxValue1),
 		ctxKey2: boolOrString(ctxValue2),
 		ctxKey3: ctxValue3,
@@ -778,7 +778,7 @@ func getFirstInterfaceEvaluationDetails(ctx context.Context) (openfeature.Interf
 	return openfeature.InterfaceEvaluationDetails{}, errors.New("no evaluation detail found in context")
 }
 
-func boolOrString(str string) interface{} {
+func boolOrString(str string) any {
 	boolean, err := strconv.ParseBool(str)
 	if err != nil {
 		return str

--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -167,7 +167,7 @@ type IntEvaluationDetails struct {
 }
 
 type InterfaceEvaluationDetails struct {
-	Value interface{}
+	Value any
 	EvaluationDetails
 }
 
@@ -182,7 +182,7 @@ type ResolutionDetail struct {
 // FlagMetadata is a structure which supports definition of arbitrary properties, with keys of type string, and values
 // of type boolean, string, int64 or float64. This structure is populated by a provider for use by an Application
 // Author (via the Evaluation API) or an Application Integrator (via hooks).
-type FlagMetadata map[string]interface{}
+type FlagMetadata map[string]any
 
 // GetString fetch string value from FlagMetadata.
 // Returns an error if the key does not exist, or, the value is of the wrong type
@@ -363,7 +363,7 @@ func (c *Client) IntValue(ctx context.Context, flag string, defaultValue int64, 
 //   - defaultValue is returned if an error occurs
 //   - evalCtx is the evaluation context used in a flag evaluation (not to be confused with ctx)
 //   - options are optional additional evaluation options e.g. WithHooks & WithHookHints
-func (c *Client) ObjectValue(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (interface{}, error) {
+func (c *Client) ObjectValue(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (any, error) {
 	details, err := c.ObjectValueDetails(ctx, flag, defaultValue, evalCtx, options...)
 	if err != nil {
 		return defaultValue, err
@@ -556,7 +556,7 @@ func (c *Client) IntValueDetails(ctx context.Context, flag string, defaultValue 
 //   - defaultValue is returned if an error occurs
 //   - evalCtx is the evaluation context used in a flag evaluation (not to be confused with ctx)
 //   - options are optional additional evaluation options e.g. WithHooks & WithHookHints
-func (c *Client) ObjectValueDetails(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error) {
+func (c *Client) ObjectValueDetails(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error) {
 	c.mx.RLock()
 	defer c.mx.RUnlock()
 
@@ -642,7 +642,7 @@ func (c *Client) Int(ctx context.Context, flag string, defaultValue int64, evalC
 //   - defaultValue is returned if an error occurs
 //   - evalCtx is the evaluation context used in a flag evaluation (not to be confused with ctx)
 //   - options are optional additional evaluation options e.g. WithHooks & WithHookHints
-func (c *Client) Object(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) interface{} {
+func (c *Client) Object(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) any {
 	value, _ := c.ObjectValue(ctx, flag, defaultValue, evalCtx, options...)
 
 	return value
@@ -678,7 +678,7 @@ func (c *Client) forTracking(ctx context.Context, evalCtx EvaluationContext) (Tr
 }
 
 func (c *Client) evaluate(
-	ctx context.Context, flag string, flagType Type, defaultValue interface{}, evalCtx EvaluationContext, options EvaluationOptions,
+	ctx context.Context, flag string, flagType Type, defaultValue any, evalCtx EvaluationContext, options EvaluationOptions,
 ) (InterfaceEvaluationDetails, error) {
 	evalDetails := InterfaceEvaluationDetails{
 		Value: defaultValue,

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -93,10 +93,10 @@ func TestRequirements_1_3(t *testing.T) {
 		StringValue(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) (string, error)
 		FloatValue(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) (float64, error)
 		IntValue(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) (int64, error)
-		ObjectValue(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (interface{}, error)
+		ObjectValue(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (any, error)
 	}
 
-	var clientI interface{} = client
+	var clientI any = client
 	if _, ok := clientI.(requirements); !ok {
 		t.Error("client returned by NewClient doesn't implement the 1.3.* requirements interface")
 	}
@@ -114,10 +114,10 @@ func TestRequirement_1_4_1(t *testing.T) {
 		StringValueDetails(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) (StringEvaluationDetails, error)
 		FloatValueDetails(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) (FloatEvaluationDetails, error)
 		IntValueDetails(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) (IntEvaluationDetails, error)
-		ObjectValueDetails(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error)
+		ObjectValueDetails(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error)
 	}
 
-	var clientI interface{} = client
+	var clientI any = client
 	if _, ok := clientI.(requirements); !ok {
 		t.Error("client returned by NewClient doesn't implement the 1.4.1 requirements interface")
 	}
@@ -142,7 +142,7 @@ const (
 	incorrectReason  = "Incorrect reason returned!"
 )
 
-var objectValue = map[string]interface{}{"foo": 1, "bar": true, "baz": "buz"}
+var objectValue = map[string]any{"foo": 1, "bar": true, "baz": "buz"}
 
 // Requirement_1_4_2
 // The `evaluation details` structure's `value` field MUST contain the evaluated flag value.
@@ -780,7 +780,7 @@ func TestRequirement_6_1(t *testing.T) {
 		Track(ctx context.Context, trackingEventName string, evalCtx EvaluationContext, details TrackingEventDetails)
 	}
 
-	var clientI interface{} = client
+	var clientI any = client
 	if _, ok := clientI.(requirements); !ok {
 		t.Error("client returned by NewClient doesn't implement the 1.6.* requirements interface")
 	}
@@ -823,7 +823,7 @@ func TestTrack(t *testing.T) {
 			eventName: "example-event",
 			inCtx: inputCtx{
 				api: EvaluationContext{
-					attributes: map[string]interface{}{
+					attributes: map[string]any{
 						"1": "api",
 						"2": "api",
 						"3": "api",
@@ -831,26 +831,26 @@ func TestTrack(t *testing.T) {
 					},
 				},
 				txn: EvaluationContext{
-					attributes: map[string]interface{}{
+					attributes: map[string]any{
 						"2": "txn",
 						"3": "txn",
 						"4": "txn",
 					},
 				},
 				client: EvaluationContext{
-					attributes: map[string]interface{}{
+					attributes: map[string]any{
 						"3": "client",
 						"4": "client",
 					},
 				},
 				invocation: EvaluationContext{
-					attributes: map[string]interface{}{
+					attributes: map[string]any{
 						"4": "invocation",
 					},
 				},
 			},
 			outCtx: EvaluationContext{
-				attributes: map[string]interface{}{
+				attributes: map[string]any{
 					"1": "api",
 					"2": "txn",
 					"3": "client",
@@ -907,7 +907,7 @@ func TestFlattenContext(t *testing.T) {
 	}{
 		"happy path": {
 			inCtx: EvaluationContext{
-				attributes: map[string]interface{}{
+				attributes: map[string]any{
 					"1": "string",
 					"2": 0.01,
 					"3": false,
@@ -923,7 +923,7 @@ func TestFlattenContext(t *testing.T) {
 		},
 		"no targeting key": {
 			inCtx: EvaluationContext{
-				attributes: map[string]interface{}{
+				attributes: map[string]any{
 					"1": "string",
 					"2": 0.01,
 					"3": false,
@@ -938,7 +938,7 @@ func TestFlattenContext(t *testing.T) {
 		"duplicated key": {
 			inCtx: EvaluationContext{
 				targetingKey: "user",
-				attributes: map[string]interface{}{
+				attributes: map[string]any{
 					TargetingKey: "not user",
 					"1":          "string",
 					"2":          0.01,
@@ -987,7 +987,7 @@ func TestBeforeHookNilContext(t *testing.T) {
 	mocks := hydratedMocksForClientTests(t, 1)
 	client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 
-	attributes := map[string]interface{}{"should": "persist"}
+	attributes := map[string]any{"should": "persist"}
 	evalCtx := EvaluationContext{attributes: attributes}
 	mocks.providerAPI.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), attributes)
 
@@ -1034,7 +1034,7 @@ func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
 
 	variant := "variant1"
 	reason := TargetingMatchReason
-	var value interface{} = nil
+	var value any = nil
 
 	mocks := hydratedMocksForClientTests(t, 1)
 	client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -1192,7 +1192,7 @@ func TestRequirement_1_7_1(t *testing.T) {
 		State() State
 	}
 
-	var clientI interface{} = client
+	var clientI any = client
 	if _, ok := clientI.(requirements); !ok {
 		t.Fatal("client des not define a status accessor which indicates the readiness of the associated provider")
 	}

--- a/openfeature/evaluation_context.go
+++ b/openfeature/evaluation_context.go
@@ -12,11 +12,11 @@ import (
 // https://openfeature.dev/specification/sections/evaluation-context
 type EvaluationContext struct {
 	targetingKey string // uniquely identifying the subject (end-user, or client service) of a flag evaluation
-	attributes   map[string]interface{}
+	attributes   map[string]any
 }
 
 // Attribute retrieves the attribute with the given key
-func (e EvaluationContext) Attribute(key string) interface{} {
+func (e EvaluationContext) Attribute(key string) any {
 	return e.attributes[key]
 }
 
@@ -26,9 +26,9 @@ func (e EvaluationContext) TargetingKey() string {
 }
 
 // Attributes returns a copy of the EvaluationContext's attributes
-func (e EvaluationContext) Attributes() map[string]interface{} {
+func (e EvaluationContext) Attributes() map[string]any {
 	// copy attributes to new map to prevent mutation (maps are passed by reference)
-	attrs := make(map[string]interface{}, len(e.attributes))
+	attrs := make(map[string]any, len(e.attributes))
 	for key, value := range e.attributes {
 		attrs[key] = value
 	}
@@ -40,9 +40,9 @@ func (e EvaluationContext) Attributes() map[string]interface{} {
 //
 // targetingKey - uniquely identifying the subject (end-user, or client service) of a flag evaluation
 // attributes - contextual data used in flag evaluation
-func NewEvaluationContext(targetingKey string, attributes map[string]interface{}) EvaluationContext {
+func NewEvaluationContext(targetingKey string, attributes map[string]any) EvaluationContext {
 	// copy attributes to new map to avoid reference being externally available, thereby enforcing immutability
-	attrs := make(map[string]interface{}, len(attributes))
+	attrs := make(map[string]any, len(attributes))
 	for key, value := range attributes {
 		attrs[key] = value
 	}
@@ -56,7 +56,7 @@ func NewEvaluationContext(targetingKey string, attributes map[string]interface{}
 // NewTargetlessEvaluationContext constructs an EvaluationContext with an empty targeting key
 //
 // attributes - contextual data used in flag evaluation
-func NewTargetlessEvaluationContext(attributes map[string]interface{}) EvaluationContext {
+func NewTargetlessEvaluationContext(attributes map[string]any) EvaluationContext {
 	return NewEvaluationContext("", attributes)
 }
 

--- a/openfeature/evaluation_context_test.go
+++ b/openfeature/evaluation_context_test.go
@@ -36,7 +36,7 @@ func TestRequirement_3_1_2(t *testing.T) {
 		t.Errorf("expected EvaluationContext.attributes key to be string, got %s", tpe.Key().Kind())
 	}
 	if tpe.Elem().Kind() != reflect.Interface {
-		t.Errorf("expected EvaluationContext.attributes value to be interface{}, got %s", tpe.Elem().Kind())
+		t.Errorf("expected EvaluationContext.attributes value to be any, got %s", tpe.Elem().Kind())
 	}
 }
 
@@ -55,7 +55,7 @@ func TestRequirement_3_2_1(t *testing.T) {
 			SetEvaluationContext(evalCtx EvaluationContext)
 		}
 
-		var clientI interface{} = client
+		var clientI any = client
 		if _, ok := clientI.(requirement); !ok {
 			t.Error("client doesn't implement the required SetEvaluationContext func signature")
 		}
@@ -69,15 +69,15 @@ func TestRequirement_3_2_1(t *testing.T) {
 			StringValue(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) (string, error)
 			FloatValue(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) (float64, error)
 			IntValue(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) (int64, error)
-			ObjectValue(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (interface{}, error)
+			ObjectValue(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (any, error)
 			BooleanValueDetails(ctx context.Context, flag string, defaultValue bool, evalCtx EvaluationContext, options ...Option) (BooleanEvaluationDetails, error)
 			StringValueDetails(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) (StringEvaluationDetails, error)
 			FloatValueDetails(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) (FloatEvaluationDetails, error)
 			IntValueDetails(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) (IntEvaluationDetails, error)
-			ObjectValueDetails(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error)
+			ObjectValueDetails(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error)
 		}
 
-		var clientI interface{} = client
+		var clientI any = client
 		if _, ok := clientI.(requirement); !ok {
 			t.Error("client doesn't implement the required func signatures containing EvaluationContext")
 		}
@@ -92,7 +92,7 @@ func TestRequirement_3_2_2(t *testing.T) {
 
 	apiEvalCtx := EvaluationContext{
 		targetingKey: "API",
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"invocationEvalCtx": true,
 			"foo":               3,
 			"user":              3,
@@ -102,7 +102,7 @@ func TestRequirement_3_2_2(t *testing.T) {
 
 	transactionEvalCtx := EvaluationContext{
 		targetingKey: "Transcation",
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"transactionEvalCtx": true,
 			"foo":                2,
 			"user":               2,
@@ -121,7 +121,7 @@ func TestRequirement_3_2_2(t *testing.T) {
 	client := GetApiInstance().GetNamedClient(t.Name())
 	clientEvalCtx := EvaluationContext{
 		targetingKey: "Client",
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"clientEvalCtx": true,
 			"foo":           1,
 			"user":          1,
@@ -131,7 +131,7 @@ func TestRequirement_3_2_2(t *testing.T) {
 
 	invocationEvalCtx := EvaluationContext{
 		targetingKey: "",
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"apiEvalCtx": true,
 			"foo":        "bar",
 		},
@@ -140,7 +140,7 @@ func TestRequirement_3_2_2(t *testing.T) {
 	mockProvider.EXPECT().Hooks().AnyTimes()
 	expectedMergedEvalCtx := EvaluationContext{
 		targetingKey: "Client",
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"apiEvalCtx":         true,
 			"transactionEvalCtx": true,
 			"invocationEvalCtx":  true,
@@ -159,7 +159,7 @@ func TestRequirement_3_2_2(t *testing.T) {
 }
 
 func TestEvaluationContext_AttributesNotPassedByReference(t *testing.T) {
-	attributes := map[string]interface{}{
+	attributes := map[string]any{
 		"foo": "bar",
 	}
 	evalCtx := NewEvaluationContext("foo", attributes)
@@ -184,7 +184,7 @@ func TestRequirement_3_3_1(t *testing.T) {
 }
 
 func TestEvaluationContext_AttributesFuncNotPassedByReference(t *testing.T) {
-	evalCtx := NewEvaluationContext("foo", map[string]interface{}{
+	evalCtx := NewEvaluationContext("foo", map[string]any{
 		"foo": "bar",
 	})
 
@@ -197,7 +197,7 @@ func TestEvaluationContext_AttributesFuncNotPassedByReference(t *testing.T) {
 }
 
 func TestNewTargetlessEvaluationContext(t *testing.T) {
-	attributes := map[string]interface{}{
+	attributes := map[string]any{
 		"foo": "bar",
 	}
 	evalCtx := NewTargetlessEvaluationContext(attributes)
@@ -211,11 +211,11 @@ func TestNewTargetlessEvaluationContext(t *testing.T) {
 }
 
 func TestMergeTransactionContext(t *testing.T) {
-	oldEvalCtx := NewEvaluationContext("old", map[string]interface{}{
+	oldEvalCtx := NewEvaluationContext("old", map[string]any{
 		"old":       true,
 		"overwrite": "old",
 	})
-	newEvalCtx := NewEvaluationContext("new", map[string]interface{}{
+	newEvalCtx := NewEvaluationContext("new", map[string]any{
 		"new":       true,
 		"overwrite": "new",
 	})
@@ -225,7 +225,7 @@ func TestMergeTransactionContext(t *testing.T) {
 
 	expectedMergedEvalCtx := EvaluationContext{
 		targetingKey: "new",
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"old":       true,
 			"new":       true,
 			"overwrite": "new",

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -81,7 +81,7 @@ func TestEventHandler_Eventing(t *testing.T) {
 		AddHandler(eventType, &callBack)
 
 		fCh := []string{"flagA"}
-		meta := map[string]interface{}{
+		meta := map[string]any{
 			"key": "value",
 		}
 
@@ -149,7 +149,7 @@ func TestEventHandler_Eventing(t *testing.T) {
 		client.AddHandler(ProviderError, &callBack)
 
 		fCh := []string{"flagA"}
-		meta := map[string]interface{}{
+		meta := map[string]any{
 			"key": "value",
 		}
 
@@ -1117,7 +1117,7 @@ func TestEventHandler_multiSubs(t *testing.T) {
 	clientB := NewClient("clientB")
 	clientB.AddHandler(ProviderStale, &callbackB)
 
-	emitDone := make(chan interface{})
+	emitDone := make(chan any)
 	eventCount := 5
 
 	// invoke events

--- a/openfeature/hooks.go
+++ b/openfeature/hooks.go
@@ -14,17 +14,17 @@ type Hook interface {
 
 // HookHints contains a map of hints for hooks
 type HookHints struct {
-	mapOfHints map[string]interface{}
+	mapOfHints map[string]any
 }
 
 // NewHookHints constructs HookHints
-func NewHookHints(mapOfHints map[string]interface{}) HookHints {
+func NewHookHints(mapOfHints map[string]any) HookHints {
 	return HookHints{mapOfHints: mapOfHints}
 }
 
 // Value returns the value at the given key in the underlying map.
 // Maintains immutability of the map.
-func (h HookHints) Value(key string) interface{} {
+func (h HookHints) Value(key string) any {
 	return h.mapOfHints[key]
 }
 
@@ -32,7 +32,7 @@ func (h HookHints) Value(key string) interface{} {
 type HookContext struct {
 	flagKey           string
 	flagType          Type
-	defaultValue      interface{}
+	defaultValue      any
 	clientMetadata    ClientMetadata
 	providerMetadata  Metadata
 	evaluationContext EvaluationContext
@@ -49,7 +49,7 @@ func (h HookContext) FlagType() Type {
 }
 
 // DefaultValue returns the hook context's default value
-func (h HookContext) DefaultValue() interface{} {
+func (h HookContext) DefaultValue() any {
 	return h.defaultValue
 }
 
@@ -73,7 +73,7 @@ func (h HookContext) EvaluationContext() EvaluationContext {
 func NewHookContext(
 	flagKey string,
 	flagType Type,
-	defaultValue interface{},
+	defaultValue any,
 	clientMetadata ClientMetadata,
 	providerMetadata Metadata,
 	evaluationContext EvaluationContext,

--- a/openfeature/hooks/logging_hook.go
+++ b/openfeature/hooks/logging_hook.go
@@ -37,12 +37,12 @@ func NewCustomLoggingHook(includeEvaluationContext bool, logger *slog.Logger) (*
 
 type MarshaledEvaluationContext struct {
 	TargetingKey string
-	Attributes   map[string]interface{}
+	Attributes   map[string]any
 }
 
-func (l LoggingHook) buildArgs(hookContext of.HookContext) ([]interface{}, error) {
+func (l LoggingHook) buildArgs(hookContext of.HookContext) ([]any, error) {
 
-	args := []interface{}{
+	args := []any{
 		DOMAIN_KEY, hookContext.ClientMetadata().Domain(),
 		PROVIDER_NAME_KEY, hookContext.ProviderMetadata().Name,
 		FLAG_KEY_KEY, hookContext.FlagKey(),

--- a/openfeature/hooks/logging_hook_test.go
+++ b/openfeature/hooks/logging_hook_test.go
@@ -92,7 +92,7 @@ func testLoggingHookLogsMessagesAsExpected(hook LoggingHook, logger *slog.Logger
 			Key:            "boolFlag",
 			State:          memprovider.Enabled,
 			DefaultVariant: "true",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"true":  true,
 				"false": false,
 			},
@@ -114,7 +114,7 @@ func testLoggingHookLogsMessagesAsExpected(hook LoggingHook, logger *slog.Logger
 			false,
 			openfeature.NewEvaluationContext(
 				"target1",
-				map[string]interface{}{
+				map[string]any{
 					"color": "green",
 				},
 			),
@@ -150,7 +150,7 @@ func testLoggingHookLogsMessagesAsExpected(hook LoggingHook, logger *slog.Logger
 			false,
 			openfeature.NewEvaluationContext(
 				"target1",
-				map[string]interface{}{
+				map[string]any{
 					"color": "green",
 				},
 			),

--- a/openfeature/hooks_test.go
+++ b/openfeature/hooks_test.go
@@ -35,7 +35,7 @@ func TestRequirement_4_1_2(t *testing.T) {
 		ProviderMetadata() Metadata
 	}
 
-	var hookI interface{} = hookCtx
+	var hookI any = hookCtx
 	if _, ok := hookI.(requirements); !ok {
 		t.Error("HookContext doesn't implement the 4.1.2 requirements interface")
 	}
@@ -81,7 +81,7 @@ func TestRequirement_4_2_1(t *testing.T) {
 		t.Errorf("expected HookHints key to be string, got %s", tpe.Key().Kind())
 	}
 	if tpe.Elem().Kind() != reflect.Interface {
-		t.Errorf("expected HookHints element to be interface{}, got %s", tpe.Elem().Kind())
+		t.Errorf("expected HookHints element to be any, got %s", tpe.Elem().Kind())
 	}
 }
 
@@ -188,7 +188,7 @@ func TestRequirement_4_3_2(t *testing.T) {
 			Before(ctx context.Context, hookContext HookContext, hookHints HookHints) (*EvaluationContext, error)
 		}
 
-		var hookI interface{} = mockHook
+		var hookI any = mockHook
 		if _, ok := hookI.(requirement); !ok {
 			t.Error("hook doesn't implement the required Before func signature")
 		}
@@ -215,7 +215,7 @@ func TestRequirement_4_3_3(t *testing.T) {
 	flagKey := "foo"
 	defaultValue := "bar"
 	evalCtx := EvaluationContext{
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"is": "a test",
 		},
 	}
@@ -232,7 +232,7 @@ func TestRequirement_4_3_3(t *testing.T) {
 	}
 	hook1EvalCtxResult := &EvaluationContext{targetingKey: "mockHook1"}
 	mockHook1.EXPECT().Before(gomock.Any(), hook1Ctx, gomock.Any()).Return(hook1EvalCtxResult, nil)
-	mockProvider.EXPECT().StringEvaluation(gomock.Any(), flagKey, defaultValue, map[string]interface{}{
+	mockProvider.EXPECT().StringEvaluation(gomock.Any(), flagKey, defaultValue, map[string]any{
 		"is":         "a test",
 		TargetingKey: "mockHook1",
 	})
@@ -272,7 +272,7 @@ func TestRequirement_4_3_4(t *testing.T) {
 	client := GetApiInstance().GetNamedClient(t.Name())
 
 	apiEvalCtx := EvaluationContext{
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"key":            "api context",
 			"lowestPriority": true,
 		},
@@ -280,7 +280,7 @@ func TestRequirement_4_3_4(t *testing.T) {
 	SetEvaluationContext(apiEvalCtx)
 
 	clientEvalCtx := EvaluationContext{
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"key":            "client context",
 			"lowestPriority": false,
 			"beatsClient":    false,
@@ -291,7 +291,7 @@ func TestRequirement_4_3_4(t *testing.T) {
 	flagKey := "foo"
 	defaultValue := "bar"
 	invEvalCtx := EvaluationContext{
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"key":         "invocation context",
 			"on":          true,
 			"beatsClient": true,
@@ -301,7 +301,7 @@ func TestRequirement_4_3_4(t *testing.T) {
 	mockProvider.EXPECT().Hooks().AnyTimes()
 
 	hookEvalCtxResult := &EvaluationContext{
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"key":        "hook value",
 			"multiplier": 3,
 		},
@@ -310,7 +310,7 @@ func TestRequirement_4_3_4(t *testing.T) {
 
 	// assert that the EvaluationContext returned by Before hooks is merged with the invocation EvaluationContext
 	expectedMergedContext := EvaluationContext{
-		attributes: map[string]interface{}{
+		attributes: map[string]any{
 			"key":            "hook value", // hook takes precedence
 			"multiplier":     3,
 			"on":             true,
@@ -371,7 +371,7 @@ func TestRequirement_4_3_5(t *testing.T) {
 			After(ctx context.Context, hookContext HookContext, flagEvaluationDetails InterfaceEvaluationDetails, hookHints HookHints) error
 		}
 
-		var hookI interface{} = mockHook
+		var hookI any = mockHook
 		if _, ok := hookI.(requirement); !ok {
 			t.Error("hook doesn't implement the required After func signature")
 		}
@@ -481,7 +481,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 			Error(ctx context.Context, hookContext HookContext, err error, hookHints HookHints)
 		}
 
-		var hookI interface{} = mockHook
+		var hookI any = mockHook
 		if _, ok := hookI.(requirement); !ok {
 			t.Error("hook doesn't implement the required Error func signature")
 		}
@@ -556,7 +556,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 			Finally(ctx context.Context, hookContext HookContext, flagEvaluationDetails InterfaceEvaluationDetails, hookHints HookHints)
 		}
 
-		var hookI interface{} = mockHook
+		var hookI any = mockHook
 		if _, ok := hookI.(requirement); !ok {
 			t.Error("hook doesn't implement the required Finally func signature")
 		}
@@ -583,7 +583,7 @@ func TestRequirement_4_4_1(t *testing.T) {
 			AddHooks(hooks ...Hook)
 		}
 
-		var clientI interface{} = client
+		var clientI any = client
 		if _, ok := clientI.(requirement); !ok {
 			t.Error("client doesn't implement the required AddHooks func signature")
 		}
@@ -596,7 +596,7 @@ func TestRequirement_4_4_1(t *testing.T) {
 			Hooks() []Hook
 		}
 
-		var providerI interface{} = mockProvider
+		var providerI any = mockProvider
 		if _, ok := providerI.(requirement); !ok {
 			t.Error("provider doesn't implement the required Hooks retrieval func signature")
 		}
@@ -611,15 +611,15 @@ func TestRequirement_4_4_1(t *testing.T) {
 			StringValue(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) (string, error)
 			FloatValue(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) (float64, error)
 			IntValue(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) (int64, error)
-			ObjectValue(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (interface{}, error)
+			ObjectValue(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (any, error)
 			BooleanValueDetails(ctx context.Context, flag string, defaultValue bool, evalCtx EvaluationContext, options ...Option) (BooleanEvaluationDetails, error)
 			StringValueDetails(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) (StringEvaluationDetails, error)
 			FloatValueDetails(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) (FloatEvaluationDetails, error)
 			IntValueDetails(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) (IntEvaluationDetails, error)
-			ObjectValueDetails(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error)
+			ObjectValueDetails(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error)
 		}
 
-		var clientI interface{} = client
+		var clientI any = client
 		if _, ok := clientI.(requirement); !ok {
 			t.Error("client doesn't implement the required func signatures containing EvaluationOptions")
 		}
@@ -864,7 +864,7 @@ func TestRequirement_4_4_7(t *testing.T) {
 // `Flag evaluation options` MAY contain `hook hints`, a map of data to be provided to hook invocations.
 func TestRequirement_4_5_1(t *testing.T) {
 	evalOptions := &EvaluationOptions{}
-	option := WithHookHints(NewHookHints(map[string]interface{}{"foo": "bar"}))
+	option := WithHookHints(NewHookHints(map[string]any{"foo": "bar"}))
 	option(evalOptions)
 	if evalOptions.hookHints.Value("foo") != "bar" {
 		t.Error("hook hints not set to EvaluationOptions")
@@ -895,7 +895,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 
 		mockProvider.EXPECT().Hooks().AnyTimes()
 
-		hookHints := NewHookHints(map[string]interface{}{"foo": "bar"})
+		hookHints := NewHookHints(map[string]any{"foo": "bar"})
 
 		mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), hookHints)
 		mockHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), hookHints)
@@ -928,7 +928,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 
 		mockProvider.EXPECT().Hooks().AnyTimes()
 
-		hookHints := NewHookHints(map[string]interface{}{"foo": "bar"})
+		hookHints := NewHookHints(map[string]any{"foo": "bar"})
 
 		mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("forced"))
 		mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), hookHints)
@@ -943,7 +943,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 
 // The hook MUST NOT alter the `hook hints` structure.
 func TestRequirement_4_5_3(t *testing.T) {
-	hookHints := NewHookHints(map[string]interface{}{"foo": "bar"})
+	hookHints := NewHookHints(map[string]any{"foo": "bar"})
 
 	metaValue := reflect.ValueOf(&hookHints).Elem()
 

--- a/openfeature/interfaces.go
+++ b/openfeature/interfaces.go
@@ -30,18 +30,18 @@ type IClient interface {
 	StringValue(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) (string, error)
 	FloatValue(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) (float64, error)
 	IntValue(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) (int64, error)
-	ObjectValue(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (interface{}, error)
+	ObjectValue(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (any, error)
 	BooleanValueDetails(ctx context.Context, flag string, defaultValue bool, evalCtx EvaluationContext, options ...Option) (BooleanEvaluationDetails, error)
 	StringValueDetails(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) (StringEvaluationDetails, error)
 	FloatValueDetails(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) (FloatEvaluationDetails, error)
 	IntValueDetails(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) (IntEvaluationDetails, error)
-	ObjectValueDetails(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error)
+	ObjectValueDetails(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) (InterfaceEvaluationDetails, error)
 
 	Boolean(ctx context.Context, flag string, defaultValue bool, evalCtx EvaluationContext, options ...Option) bool
 	String(ctx context.Context, flag string, defaultValue string, evalCtx EvaluationContext, options ...Option) string
 	Float(ctx context.Context, flag string, defaultValue float64, evalCtx EvaluationContext, options ...Option) float64
 	Int(ctx context.Context, flag string, defaultValue int64, evalCtx EvaluationContext, options ...Option) int64
-	Object(ctx context.Context, flag string, defaultValue interface{}, evalCtx EvaluationContext, options ...Option) interface{}
+	Object(ctx context.Context, flag string, defaultValue any, evalCtx EvaluationContext, options ...Option) any
 
 	State() State
 

--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -102,7 +102,7 @@ func (i InMemoryProvider) IntEvaluation(ctx context.Context, flag string, defaul
 	}
 }
 
-func (i InMemoryProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue interface{}, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+func (i InMemoryProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
 	memoryFlag, details, ok := i.find(flag)
 	if !ok {
 		return openfeature.InterfaceResolutionDetail{
@@ -113,7 +113,7 @@ func (i InMemoryProvider) ObjectEvaluation(ctx context.Context, flag string, def
 
 	resolveFlag, detail := memoryFlag.Resolve(defaultValue, evalCtx)
 
-	var result interface{}
+	var result any
 	if resolveFlag != nil {
 		result = resolveFlag
 	} else {
@@ -156,7 +156,7 @@ func (i InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.Provide
 // helpers
 
 // genericResolve is a helper to extract type verified evaluation and fill openfeature.ProviderResolutionDetail
-func genericResolve[T comparable](value interface{}, defaultValue T, detail *openfeature.ProviderResolutionDetail) T {
+func genericResolve[T comparable](value any, defaultValue T, detail *openfeature.ProviderResolutionDetail) T {
 	v, ok := value.(T)
 
 	if ok {
@@ -175,19 +175,19 @@ type State string
 
 // ContextEvaluator is a callback to perform openfeature.EvaluationContext backed evaluations.
 // This is a callback implemented by the flag definer.
-type ContextEvaluator *func(this InMemoryFlag, evalCtx openfeature.FlattenedContext) (interface{}, openfeature.ProviderResolutionDetail)
+type ContextEvaluator *func(this InMemoryFlag, evalCtx openfeature.FlattenedContext) (any, openfeature.ProviderResolutionDetail)
 
 // InMemoryFlag is the feature flag representation accepted by InMemoryProvider
 type InMemoryFlag struct {
 	Key              string
 	State            State
 	DefaultVariant   string
-	Variants         map[string]interface{}
+	Variants         map[string]any
 	ContextEvaluator ContextEvaluator
 }
 
-func (flag *InMemoryFlag) Resolve(defaultValue interface{}, evalCtx openfeature.FlattenedContext) (
-	interface{}, openfeature.ProviderResolutionDetail) {
+func (flag *InMemoryFlag) Resolve(defaultValue any, evalCtx openfeature.FlattenedContext) (
+	any, openfeature.ProviderResolutionDetail) {
 
 	// check the state
 	if flag.State == Disabled {
@@ -212,6 +212,6 @@ func (flag *InMemoryFlag) Resolve(defaultValue interface{}, evalCtx openfeature.
 
 type InMemoryEvent struct {
 	Value             float64
-	Data              map[string]interface{}
-	ContextAttributes map[string]interface{}
+	Data              map[string]any
+	ContextAttributes map[string]any
 }

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -13,7 +13,7 @@ func TestInMemoryProvider_boolean(t *testing.T) {
 			Key:            "boolFlag",
 			State:          Enabled,
 			DefaultVariant: "true",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"true":  true,
 				"false": false,
 			},
@@ -38,7 +38,7 @@ func TestInMemoryProvider_String(t *testing.T) {
 			Key:            "stringFlag",
 			State:          Enabled,
 			DefaultVariant: "stringOne",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"stringOne": "hello",
 				"stringTwo": "GoodBye",
 			},
@@ -63,7 +63,7 @@ func TestInMemoryProvider_Float(t *testing.T) {
 			Key:            "floatFlag",
 			State:          Enabled,
 			DefaultVariant: "fOne",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"fOne": 1.1,
 				"fTwo": 2.2,
 			},
@@ -88,7 +88,7 @@ func TestInMemoryProvider_Int(t *testing.T) {
 			Key:            "intFlag",
 			State:          Enabled,
 			DefaultVariant: "max",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"min": -9223372036854775808,
 				"max": 9223372036854775807,
 			},
@@ -113,7 +113,7 @@ func TestInMemoryProvider_Object(t *testing.T) {
 			Key:            "objectFlag",
 			State:          Enabled,
 			DefaultVariant: "A",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"A": "SomeResult",
 				"B": "OtherResult",
 			},
@@ -135,7 +135,7 @@ func TestInMemoryProvider_WithContext(t *testing.T) {
 	var variantKey = "VariantSelector"
 
 	// simple context handling - variant is selected from key and returned
-	var evaluator = func(callerFlag InMemoryFlag, evalCtx openfeature.FlattenedContext) (interface{}, openfeature.ProviderResolutionDetail) {
+	var evaluator = func(callerFlag InMemoryFlag, evalCtx openfeature.FlattenedContext) (any, openfeature.ProviderResolutionDetail) {
 		s := evalCtx[variantKey]
 		return callerFlag.Variants[s.(string)], openfeature.ProviderResolutionDetail{}
 	}
@@ -145,7 +145,7 @@ func TestInMemoryProvider_WithContext(t *testing.T) {
 			Key:            "contextFlag",
 			State:          Enabled,
 			DefaultVariant: "true",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"true":  true,
 				"false": false,
 			},
@@ -157,7 +157,7 @@ func TestInMemoryProvider_WithContext(t *testing.T) {
 
 	t.Run("test with context", func(t *testing.T) {
 
-		evaluation := memoryProvider.BooleanEvaluation(ctx, "contextFlag", true, map[string]interface{}{
+		evaluation := memoryProvider.BooleanEvaluation(ctx, "contextFlag", true, map[string]any{
 			variantKey: "false",
 		})
 
@@ -195,7 +195,7 @@ func TestInMemoryProvider_TypeMismatch(t *testing.T) {
 			Key:            "boolFlag",
 			State:          Enabled,
 			DefaultVariant: "true",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"true":  true,
 				"false": false,
 			},
@@ -224,7 +224,7 @@ func TestInMemoryProvider_Disabled(t *testing.T) {
 			Key:            "boolFlag",
 			State:          Disabled,
 			DefaultVariant: "true",
-			Variants: map[string]interface{}{
+			Variants: map[string]any{
 				"true":  true,
 				"false": false,
 			},

--- a/openfeature/noop_provider.go
+++ b/openfeature/noop_provider.go
@@ -56,7 +56,7 @@ func (e NoopProvider) IntEvaluation(ctx context.Context, flag string, defaultVal
 }
 
 // ObjectEvaluation returns an object flag
-func (e NoopProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue interface{}, evalCtx FlattenedContext) InterfaceResolutionDetail {
+func (e NoopProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, evalCtx FlattenedContext) InterfaceResolutionDetail {
 	return InterfaceResolutionDetail{
 		Value: defaultValue,
 		ProviderResolutionDetail: ProviderResolutionDetail{

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -777,7 +777,7 @@ func TestForNilProviders(t *testing.T) {
 	}
 }
 
-func use(vals ...interface{}) {
+func use(vals ...any) {
 	for _, val := range vals {
 		_ = val
 	}
@@ -787,9 +787,9 @@ func setupProviderWithSemaphores() (struct {
 	FeatureProvider
 	StateHandler
 	EventHandler
-}, chan interface{}, chan interface{}) {
-	intiSem := make(chan interface{}, 1)
-	shutdownSem := make(chan interface{}, 1)
+}, chan any, chan any) {
+	intiSem := make(chan any, 1)
+	shutdownSem := make(chan any, 1)
 
 	sh := &stateHandlerForTests{
 		// Semaphore must be invoked

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -39,7 +39,7 @@ const (
 
 // FlattenedContext contains metadata for a given flag evaluation in a flattened structure.
 // TargetingKey ("targetingKey") is stored as a string value if provided in the evaluation context.
-type FlattenedContext map[string]interface{}
+type FlattenedContext map[string]any
 
 // Reason indicates the semantic reason for a returned flag value
 type Reason string
@@ -52,7 +52,7 @@ type FeatureProvider interface {
 	StringEvaluation(ctx context.Context, flag string, defaultValue string, evalCtx FlattenedContext) StringResolutionDetail
 	FloatEvaluation(ctx context.Context, flag string, defaultValue float64, evalCtx FlattenedContext) FloatResolutionDetail
 	IntEvaluation(ctx context.Context, flag string, defaultValue int64, evalCtx FlattenedContext) IntResolutionDetail
-	ObjectEvaluation(ctx context.Context, flag string, defaultValue interface{}, evalCtx FlattenedContext) InterfaceResolutionDetail
+	ObjectEvaluation(ctx context.Context, flag string, defaultValue any, evalCtx FlattenedContext) InterfaceResolutionDetail
 	Hooks() []Hook
 }
 
@@ -104,7 +104,7 @@ type EventType string
 type ProviderEventDetails struct {
 	Message       string
 	FlagChanges   []string
-	EventMetadata map[string]interface{}
+	EventMetadata map[string]any
 	ErrorCode     ErrorCode
 }
 
@@ -187,9 +187,9 @@ type IntResolutionDetail struct {
 	ProviderResolutionDetail
 }
 
-// InterfaceResolutionDetail provides a resolution detail with interface{} type
+// InterfaceResolutionDetail provides a resolution detail with any type
 type InterfaceResolutionDetail struct {
-	Value interface{}
+	Value any
 	ProviderResolutionDetail
 }
 
@@ -201,14 +201,14 @@ type Metadata struct {
 // TrackingEventDetails provides a tracking details with float64 value
 type TrackingEventDetails struct {
 	value      float64
-	attributes map[string]interface{}
+	attributes map[string]any
 }
 
 // NewTrackingEventDetails return TrackingEventDetails associated with numeric value value
 func NewTrackingEventDetails(value float64) TrackingEventDetails {
 	return TrackingEventDetails{
 		value:      value,
-		attributes: make(map[string]interface{}),
+		attributes: make(map[string]any),
 	}
 }
 
@@ -216,15 +216,15 @@ func NewTrackingEventDetails(value float64) TrackingEventDetails {
 // If the key already exists in TrackingEventDetails, it will be replaced.
 //
 // Usage: trackingEventDetails.Add('active-time', 2).Add('unit': 'seconds')
-func (t TrackingEventDetails) Add(key string, value interface{}) TrackingEventDetails {
+func (t TrackingEventDetails) Add(key string, value any) TrackingEventDetails {
 	t.attributes[key] = value
 	return t
 }
 
 // Attributes return a map contains the key-value pairs stored in TrackingEventDetails.
-func (t TrackingEventDetails) Attributes() map[string]interface{} {
+func (t TrackingEventDetails) Attributes() map[string]any {
 	// copy fields to new map to prevent mutation (maps are passed by reference)
-	fields := make(map[string]interface{}, len(t.attributes))
+	fields := make(map[string]any, len(t.attributes))
 	for key, value := range t.attributes {
 		fields[key] = value
 	}
@@ -232,7 +232,7 @@ func (t TrackingEventDetails) Attributes() map[string]interface{} {
 }
 
 // Attribute retrieves the attribute with the given key.
-func (t TrackingEventDetails) Attribute(key string) interface{} {
+func (t TrackingEventDetails) Attribute(key string) any {
 	return t.attributes[key]
 }
 

--- a/openfeature/provider_test.go
+++ b/openfeature/provider_test.go
@@ -18,7 +18,7 @@ func TestRequirement_2_1_1(t *testing.T) {
 		Metadata() Metadata
 	}
 
-	var mockProviderI interface{} = mockProvider
+	var mockProviderI any = mockProvider
 	if _, ok := mockProviderI.(requirements); !ok {
 		t.Error("provider interface doesn't define the Metadata signature")
 	}
@@ -46,10 +46,10 @@ func TestRequirement_2_2_1(t *testing.T) {
 		StringEvaluation(ctx context.Context, flag string, defaultValue string, evalCtx FlattenedContext) StringResolutionDetail
 		FloatEvaluation(ctx context.Context, flag string, defaultValue float64, evalCtx FlattenedContext) FloatResolutionDetail
 		IntEvaluation(ctx context.Context, flag string, defaultValue int64, evalCtx FlattenedContext) IntResolutionDetail
-		ObjectEvaluation(ctx context.Context, flag string, defaultValue interface{}, evalCtx FlattenedContext) InterfaceResolutionDetail
+		ObjectEvaluation(ctx context.Context, flag string, defaultValue any, evalCtx FlattenedContext) InterfaceResolutionDetail
 	}
 
-	var mockProviderI interface{} = mockProvider
+	var mockProviderI any = mockProvider
 	if _, ok := mockProviderI.(requirements); !ok {
 		t.Error("provider interface doesn't define the evaluation signatures")
 	}
@@ -92,11 +92,11 @@ func TestTrackingEventDetails_Add(t *testing.T) {
 
 	tests := map[string]struct {
 		inputDetails TrackingEventDetails
-		addKeyPair   map[string]interface{}
+		addKeyPair   map[string]any
 	}{
 		"added correctly": {
 			inputDetails: NewTrackingEventDetails(1),
-			addKeyPair: map[string]interface{}{
+			addKeyPair: map[string]any{
 				"foo": "bar",
 				"baz": 1,
 				"qux": dummyStruct{

--- a/openfeature/reference.go
+++ b/openfeature/reference.go
@@ -9,7 +9,7 @@ func newProviderRef(provider FeatureProvider) providerReference {
 	return providerReference{
 		featureProvider:   provider,
 		kind:              reflect.TypeOf(provider).Kind(),
-		shutdownSemaphore: make(chan interface{}),
+		shutdownSemaphore: make(chan any),
 	}
 }
 
@@ -18,7 +18,7 @@ func newProviderRef(provider FeatureProvider) providerReference {
 type providerReference struct {
 	featureProvider   FeatureProvider
 	kind              reflect.Kind
-	shutdownSemaphore chan interface{}
+	shutdownSemaphore chan any
 }
 
 func (pr providerReference) equals(other providerReference) bool {

--- a/openfeature/testing/testprovider.go
+++ b/openfeature/testing/testprovider.go
@@ -58,7 +58,7 @@ func (tp TestProvider) IntEvaluation(ctx context.Context, flag string, defaultVa
 	return tp.getProvider().IntEvaluation(ctx, flag, defaultValue, flCtx)
 }
 
-func (tp TestProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue interface{}, flCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+func (tp TestProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, flCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
 	return tp.getProvider().ObjectEvaluation(ctx, flag, defaultValue, flCtx)
 }
 
@@ -94,12 +94,12 @@ func (tp TestProvider) getProvider() openfeature.FeatureProvider {
 
 var goroutineLocalData sync.Map
 
-func storeGoroutineLocal(value interface{}) {
+func storeGoroutineLocal(value any) {
 	gID := getGoroutineID()
 	goroutineLocalData.Store(fmt.Sprintf("%d_%v", gID, testNameKey), value)
 }
 
-func getGoroutineLocal() interface{} {
+func getGoroutineLocal() any {
 	gID := getGoroutineID()
 	value, _ := goroutineLocalData.Load(fmt.Sprintf("%d_%v", gID, testNameKey))
 	return value

--- a/pkg/openfeature/evaluation_context.go
+++ b/pkg/openfeature/evaluation_context.go
@@ -18,7 +18,7 @@ type EvaluationContext = openfeature.EvaluationContext
 //
 // Deprecated: use
 // github.com/open-feature/go-sdk/openfeature.NewEvaluationContext, instead.
-func NewEvaluationContext(targetingKey string, attributes map[string]interface{}) EvaluationContext {
+func NewEvaluationContext(targetingKey string, attributes map[string]any) EvaluationContext {
 	return openfeature.NewEvaluationContext(targetingKey, attributes)
 }
 
@@ -29,6 +29,6 @@ func NewEvaluationContext(targetingKey string, attributes map[string]interface{}
 // Deprecated: use
 // github.com/open-feature/go-sdk/openfeature.NewTargetlessEvaluationContext,
 // instead.
-func NewTargetlessEvaluationContext(attributes map[string]interface{}) EvaluationContext {
+func NewTargetlessEvaluationContext(attributes map[string]any) EvaluationContext {
 	return openfeature.NewTargetlessEvaluationContext(attributes)
 }

--- a/pkg/openfeature/hooks.go
+++ b/pkg/openfeature/hooks.go
@@ -21,7 +21,7 @@ type HookHints = openfeature.HookHints
 //
 // Deprecated: use github.com/open-feature/go-sdk/openfeature.NewHookHints,
 // instead.
-func NewHookHints(mapOfHints map[string]interface{}) HookHints {
+func NewHookHints(mapOfHints map[string]any) HookHints {
 	return openfeature.NewHookHints(mapOfHints)
 }
 
@@ -39,7 +39,7 @@ type HookContext = openfeature.HookContext
 func NewHookContext(
 	flagKey string,
 	flagType Type,
-	defaultValue interface{},
+	defaultValue any,
 	clientMetadata ClientMetadata,
 	providerMetadata Metadata,
 	evaluationContext EvaluationContext,

--- a/pkg/openfeature/provider.go
+++ b/pkg/openfeature/provider.go
@@ -173,7 +173,7 @@ type FloatResolutionDetail = openfeature.FloatResolutionDetail
 // github.com/open-feature/go-sdk/openfeature.IntResolutionDetail, instead.
 type IntResolutionDetail = openfeature.IntResolutionDetail
 
-// InterfaceResolutionDetail provides a resolution detail with interface{} type
+// InterfaceResolutionDetail provides a resolution detail with any type
 //
 // Deprecated: use
 // github.com/open-feature/go-sdk/openfeature.InterfaceResolutionDetail,


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Replace usage of `interface{}` with `any`.
This is a stylistic update only. See issue #358 for details.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #358 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

