### PR TITLE
chore: add `misspell` and `dupword` linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,8 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - misspell
+    - dupword
 
 issues:
   max-issues-per-linter: 0

--- a/openfeature/hooks/logging_hook_test.go
+++ b/openfeature/hooks/logging_hook_test.go
@@ -122,7 +122,7 @@ func testLoggingHookLogsMessagesAsExpected(hook LoggingHook, logger *slog.Logger
 			t.Error("expected nil error")
 		}
 		if res != true {
-			t.Errorf("incorect evaluation, expected %t, got %t", true, res)
+			t.Errorf("incorrect evaluation, expected %t, got %t", true, res)
 		}
 
 		ms := prepareOutput(buf, t)
@@ -160,7 +160,7 @@ func testLoggingHookLogsMessagesAsExpected(hook LoggingHook, logger *slog.Logger
 			t.Error("expected error")
 		}
 		if res != false {
-			t.Errorf("incorect evaluation, expected %t, got %t", false, res)
+			t.Errorf("incorrect evaluation, expected %t, got %t", false, res)
 		}
 
 		ms := prepareOutput(buf, t)

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -27,7 +27,7 @@ func TestInMemoryProvider_boolean(t *testing.T) {
 		evaluation := memoryProvider.BooleanEvaluation(ctx, "boolFlag", false, nil)
 
 		if evaluation.Value != true {
-			t.Errorf("incorect evaluation, expected %t, got %t", true, evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %t, got %t", true, evaluation.Value)
 		}
 	})
 }
@@ -52,7 +52,7 @@ func TestInMemoryProvider_String(t *testing.T) {
 		evaluation := memoryProvider.StringEvaluation(ctx, "stringFlag", "none", nil)
 
 		if evaluation.Value != "hello" {
-			t.Errorf("incorect evaluation, expected %s, got %s", "hello", evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %s, got %s", "hello", evaluation.Value)
 		}
 	})
 }
@@ -77,7 +77,7 @@ func TestInMemoryProvider_Float(t *testing.T) {
 		evaluation := memoryProvider.FloatEvaluation(ctx, "floatFlag", 1.0, nil)
 
 		if evaluation.Value != 1.1 {
-			t.Errorf("incorect evaluation, expected %f, got %f", 1.1, evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %f, got %f", 1.1, evaluation.Value)
 		}
 	})
 }
@@ -102,7 +102,7 @@ func TestInMemoryProvider_Int(t *testing.T) {
 		evaluation := memoryProvider.IntEvaluation(ctx, "intFlag", 1, nil)
 
 		if evaluation.Value != 9223372036854775807 {
-			t.Errorf("incorect evaluation, expected %d, got %d", 1, evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %d, got %d", 1, evaluation.Value)
 		}
 	})
 }
@@ -126,7 +126,7 @@ func TestInMemoryProvider_Object(t *testing.T) {
 		evaluation := memoryProvider.ObjectEvaluation(ctx, "objectFlag", "unknown", nil)
 
 		if evaluation.Value != "SomeResult" {
-			t.Errorf("incorect evaluation, expected %v, got %v", "SomeResult", evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %v, got %v", "SomeResult", evaluation.Value)
 		}
 	})
 }
@@ -162,7 +162,7 @@ func TestInMemoryProvider_WithContext(t *testing.T) {
 		})
 
 		if evaluation.Value != false {
-			t.Errorf("incorect evaluation, expected %v, got %v", false, evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %v, got %v", false, evaluation.Value)
 		}
 	})
 }
@@ -176,15 +176,15 @@ func TestInMemoryProvider_MissingFlag(t *testing.T) {
 		evaluation := memoryProvider.StringEvaluation(ctx, "missing-flag", "GoodBye", nil)
 
 		if evaluation.Value != "GoodBye" {
-			t.Errorf("incorect evaluation, expected %v, got %v", "SomeResult", evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %v, got %v", "SomeResult", evaluation.Value)
 		}
 
 		if evaluation.Reason != openfeature.ErrorReason {
-			t.Errorf("incorect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.Reason)
+			t.Errorf("incorrect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.Reason)
 		}
 
 		if evaluation.ResolutionDetail().ErrorCode != openfeature.FlagNotFoundCode {
-			t.Errorf("incorect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.ResolutionDetail().ErrorCode)
+			t.Errorf("incorrect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.ResolutionDetail().ErrorCode)
 		}
 	})
 }
@@ -209,11 +209,11 @@ func TestInMemoryProvider_TypeMismatch(t *testing.T) {
 		evaluation := memoryProvider.StringEvaluation(ctx, "boolFlag", "GoodBye", nil)
 
 		if evaluation.Value != "GoodBye" {
-			t.Errorf("incorect evaluation, expected %v, got %v", "SomeResult", evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %v, got %v", "SomeResult", evaluation.Value)
 		}
 
 		if evaluation.ResolutionDetail().ErrorCode != openfeature.TypeMismatchCode {
-			t.Errorf("incorect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.Reason)
+			t.Errorf("incorrect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.Reason)
 		}
 	})
 }
@@ -238,11 +238,11 @@ func TestInMemoryProvider_Disabled(t *testing.T) {
 		evaluation := memoryProvider.BooleanEvaluation(ctx, "boolFlag", false, nil)
 
 		if evaluation.Value != false {
-			t.Errorf("incorect evaluation, expected %v, got %v", false, evaluation.Value)
+			t.Errorf("incorrect evaluation, expected %v, got %v", false, evaluation.Value)
 		}
 
 		if evaluation.Reason != openfeature.DisabledReason {
-			t.Errorf("incorect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.Reason)
+			t.Errorf("incorrect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.Reason)
 		}
 	})
 }

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -204,7 +204,7 @@ type TrackingEventDetails struct {
 	attributes map[string]any
 }
 
-// NewTrackingEventDetails return TrackingEventDetails associated with numeric value value
+// NewTrackingEventDetails return TrackingEventDetails associated with numeric value
 func NewTrackingEventDetails(value float64) TrackingEventDetails {
 	return TrackingEventDetails{
 		value:      value,

--- a/openfeature/resolution_error.go
+++ b/openfeature/resolution_error.go
@@ -10,7 +10,7 @@ type ErrorCode string
 const (
 	// ProviderNotReadyCode - the value was resolved before the provider was ready.
 	ProviderNotReadyCode ErrorCode = "PROVIDER_NOT_READY"
-	// ProviderFatalCode - a fatal provider error occured
+	// ProviderFatalCode - a fatal provider error occurred
 	ProviderFatalCode ErrorCode = "PROVIDER_FATAL"
 	// FlagNotFoundCode - the flag could not be found.
 	FlagNotFoundCode ErrorCode = "FLAG_NOT_FOUND"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Add the misspell and dupword linters to catch typos. Misspell checks for common misspellings and dupword checks for duplicate consecutive words like "the the".
Also ran `make fix` to auto-fix all the findings.

https://golangci-lint.run/usage/linters/

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

