### PR TITLE
build: Use a less restrictive glob pattern to ignore mocks in coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "openfeature/*_mock.go"
+  - "**/*_mock.go"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This will allow for mocks in any folder to be ignored rather than just in the `openfeature` package. This will unblock #354 

### Related Issues

Unblocks #354

### Notes

I added new mocks in another PR, however the ignore path only for coverage only specifies the `openfeature` package for mocks. Since I introduced new mocks in another package the coverage percentage dropped below the allowed threshold blocking my PR.

### Follow-up Tasks

Nada

### How to test

Not applicable

