### PR TITLE
chore: enable gofumpt and gci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,8 @@ version: "2"
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
+    - gci
 
 linters:
   default: none

--- a/e2e/evaluation_fuzz_test.go
+++ b/e2e/evaluation_fuzz_test.go
@@ -2,10 +2,11 @@ package e2e_test
 
 import (
 	"context"
-	"github.com/open-feature/go-sdk/openfeature"
-	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"strings"
 	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 )
 
 func setupFuzzClient(f *testing.F) *openfeature.Client {

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -3,11 +3,12 @@ package openfeature
 import (
 	"context"
 	"errors"
-	"go.uber.org/mock/gomock"
 	"math"
 	"reflect"
 	"testing"
 	"time"
+
+	"go.uber.org/mock/gomock"
 )
 
 type clientMocks struct {
@@ -858,7 +859,6 @@ func TestTrack(t *testing.T) {
 				},
 			},
 			provider: func(tc *testcase, mockProvider *MockFeatureProvider) FeatureProvider {
-
 				provider := &mockTrackingProvider{
 					MockTracker:         NewMockTracker(mockProvider.ctrl),
 					MockFeatureProvider: mockProvider,
@@ -874,7 +874,6 @@ func TestTrack(t *testing.T) {
 			eventName: "example-event",
 			outCtx:    EvaluationContext{},
 			provider: func(tc *testcase, provider *MockFeatureProvider) FeatureProvider {
-
 				return provider
 			},
 		},
@@ -1069,7 +1068,6 @@ func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
 }
 
 func TestFlagMetadataAccessors(t *testing.T) {
-
 	t.Run("bool", func(t *testing.T) {
 		expectedValue := true
 		key := "bool"
@@ -1185,7 +1183,6 @@ func TestFlagMetadataAccessors(t *testing.T) {
 // The client MUST define a provider status accessor which indicates the readiness of the associated provider.
 // with possible values NOT_READY, READY, STALE, ERROR, or FATAL.
 func TestRequirement_1_7_1(t *testing.T) {
-
 	client := NewClient("test-client")
 
 	type requirements interface {
@@ -1250,7 +1247,6 @@ func TestRequirement_1_7_3(t *testing.T) {
 	if GetApiInstance().GetNamedClient(t.Name()).State() != ErrorState {
 		t.Fatalf("expected client to report ERROR state")
 	}
-
 }
 
 // The client's provider status accessor MUST indicate FATAL if the initialize function of the associated provider
@@ -1276,7 +1272,6 @@ func TestRequirement_1_7_4(t *testing.T) {
 	if GetApiInstance().GetNamedClient(t.Name()).State() != ErrorState {
 		t.Fatalf("expected client to report ERROR state")
 	}
-
 }
 
 // The client's provider status accessor MUST indicate FATAL if the initialize function of the associated provider
@@ -1302,7 +1297,6 @@ func TestRequirement_1_7_5(t *testing.T) {
 	if GetApiInstance().GetNamedClient(t.Name()).State() != FatalState {
 		t.Fatalf("expected client to report ERROR state")
 	}
-
 }
 
 // The client MUST default, run error hooks, and indicate an error if flag resolution is attempted while the provider
@@ -1398,7 +1392,6 @@ func TestRequirement_1_7_7(t *testing.T) {
 
 // Implementations SHOULD propagate the error code returned from any provider lifecycle methods.
 func TestRequirement_1_7_8(t *testing.T) {
-
 	t.Skip("Test not yet implemented")
 }
 
@@ -1454,5 +1447,4 @@ func TestRequirement_5_3_5(t *testing.T) {
 	eventually(t, func() bool {
 		return GetApiInstance().GetNamedClient(t.Name()).State() == FatalState
 	}, time.Second, 100*time.Millisecond, "expected client to report FATAL state")
-
 }

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -9,14 +9,12 @@ import (
 )
 
 func init() {
-
 }
 
 // Requirement 5.1.1 The provider MAY define a mechanism for signaling the occurrence of one of a set of events,
 // including PROVIDER_READY, PROVIDER_ERROR, PROVIDER_CONFIGURATION_CHANGED and PROVIDER_STALE,
 // with a provider event details payload.
 func TestEventHandler_RegisterUnregisterEventProvider(t *testing.T) {
-
 	t.Run("Accepts addition of eventing providers", func(t *testing.T) {
 		eventingImpl := &ProviderEventing{}
 
@@ -474,7 +472,6 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 			break
 		}
 	})
-
 }
 
 // Requirement 5.3.2 If the provider's initialize function terminates abnormally, PROVIDER_ERROR handlers MUST run.
@@ -628,7 +625,6 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 			break
 		}
 	})
-
 }
 
 // Requirement 5.3.3 PROVIDER_READY handlers attached after the provider is already in a ready state MUST run immediately.
@@ -1185,7 +1181,6 @@ func TestEventHandler_multiSubs(t *testing.T) {
 
 func TestEventHandler_1ToNMapping(t *testing.T) {
 	t.Run("provider eventing must be subscribed only once", func(t *testing.T) {
-
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
 		}
@@ -1226,7 +1221,6 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 	})
 
 	t.Run("avoid unsubscribe from active providers - default and named", func(t *testing.T) {
-
 		eventingProvider := struct {
 			FeatureProvider
 			EventHandler
@@ -1270,7 +1264,6 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 	})
 
 	t.Run("avoid unsubscribe from active providers - named only", func(t *testing.T) {
-
 		eventingProvider := struct {
 			FeatureProvider
 			EventHandler
@@ -1314,7 +1307,6 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 	})
 
 	t.Run("unbound providers must be removed from active subscriptions", func(t *testing.T) {
-
 		eventingProvider := struct {
 			FeatureProvider
 			EventHandler

--- a/openfeature/hooks_test.go
+++ b/openfeature/hooks_test.go
@@ -3,11 +3,11 @@ package openfeature
 import (
 	"context"
 	"errors"
-	"go.uber.org/mock/gomock"
 	"reflect"
 	"testing"
 	"time"
 
+	"go.uber.org/mock/gomock"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )

--- a/openfeature/noop_provider.go
+++ b/openfeature/noop_provider.go
@@ -3,8 +3,7 @@ package openfeature
 import "context"
 
 // NoopProvider implements the FeatureProvider interface and provides functions for evaluating flags
-type NoopProvider struct {
-}
+type NoopProvider struct{}
 
 // Metadata returns the metadata of the provider
 func (e NoopProvider) Metadata() Metadata {

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -85,7 +85,7 @@ func TestRequirement_1_1_2_2(t *testing.T) {
 
 		provider, initSem, _ := setupProviderWithSemaphores()
 
-		var client = "client"
+		client := "client"
 
 		err := SetNamedProvider(client, provider)
 		if err != nil {
@@ -141,7 +141,6 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 		case <-shutdownSem:
 			break
 		}
-
 	})
 
 	t.Run("named provider", func(t *testing.T) {
@@ -149,7 +148,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 
 		provider, initSem, shutdownSem := setupProviderWithSemaphores()
 
-		var client = "client"
+		client := "client"
 
 		err := SetNamedProvider(client, provider)
 		if err != nil {
@@ -261,7 +260,7 @@ func TestRequirement_1_1_2_4(t *testing.T) {
 
 	t.Run("default provider", func(t *testing.T) {
 		// given - a provider with state handling capability, with substantial initializing delay
-		var initialized = false
+		initialized := false
 
 		provider := struct {
 			FeatureProvider
@@ -291,7 +290,7 @@ func TestRequirement_1_1_2_4(t *testing.T) {
 
 	t.Run("named provider", func(t *testing.T) {
 		// given - a provider with state handling capability, with substantial initializing delay
-		var initialized = false
+		initialized := false
 
 		provider := struct {
 			FeatureProvider
@@ -361,12 +360,11 @@ func TestRequirement_1_1_2_4(t *testing.T) {
 		if errEvent.Message == "" {
 			t.Fatal("expected non empty event message, but got empty")
 		}
-
 	})
 
 	t.Run("async registration to validate by contradiction", func(t *testing.T) {
 		// given - a provider with state handling capability, with substantial initializing delay
-		var initialized = false
+		initialized := false
 
 		s := make(chan struct{}) // to block the initialization
 		provider := struct {
@@ -588,7 +586,6 @@ func TestRequirement_1_6_1(t *testing.T) {
 }
 
 func TestRequirement_EventCompliance(t *testing.T) {
-
 	// The client MUST provide a function for associating handler functions with a particular provider event type.
 	// The API and client MUST provide a function allowing the removal of event handlers.
 	t.Run("requirement_5_2_1 & requirement_5_2_1", func(t *testing.T) {
@@ -789,7 +786,8 @@ func setupProviderWithSemaphores() (struct {
 	FeatureProvider
 	StateHandler
 	EventHandler
-}, chan any, chan any) {
+}, chan any, chan any,
+) {
 	intiSem := make(chan any, 1)
 	shutdownSem := make(chan any, 1)
 

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -74,8 +74,7 @@ type Tracker interface {
 
 // NoopStateHandler is a noop StateHandler implementation
 // Status always set to ReadyState to comply with specification
-type NoopStateHandler struct {
-}
+type NoopStateHandler struct{}
 
 func (s *NoopStateHandler) Init(e EvaluationContext) error {
 	// NOOP
@@ -123,8 +122,7 @@ type EventDetails struct {
 type EventCallback *func(details EventDetails)
 
 // NoopEventHandler is the out-of-the-box EventHandler which is noop
-type NoopEventHandler struct {
-}
+type NoopEventHandler struct{}
 
 func (s NoopEventHandler) EventChannel() <-chan Event {
 	return make(chan Event, 1)

--- a/openfeature/reference_test.go
+++ b/openfeature/reference_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestProviderReferenceEquals(t *testing.T) {
-
 	type myProvider struct {
 		NoopProvider
 		field string
@@ -20,7 +19,6 @@ func TestProviderReferenceEquals(t *testing.T) {
 		pr2      providerReference
 		expected bool
 	}{
-
 		{
 			name:     "both pointers, different instances",
 			pr1:      newProviderRef(&p1),

--- a/openfeature/testing/testprovider_test.go
+++ b/openfeature/testing/testprovider_test.go
@@ -146,7 +146,6 @@ func TestTestAwareProvider(t *testing.T) {
 }
 
 func Test_TestAwareProviderPanics(t *testing.T) {
-
 	t.Run("provider panics if no test name was provided by calling SetProvider()", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {

--- a/openfeature/util_test.go
+++ b/openfeature/util_test.go
@@ -8,10 +8,12 @@ import (
 // Test Utils
 
 // event handlers
-var h1 func(details EventDetails)
-var h2 func(details EventDetails)
-var h3 func(details EventDetails)
-var h4 func(details EventDetails)
+var (
+	h1 func(details EventDetails)
+	h2 func(details EventDetails)
+	h3 func(details EventDetails)
+	h4 func(details EventDetails)
+)
 
 func init() {
 	h1 = func(details EventDetails) {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Enable both gofumpt (instead of gofmt) and gci formatters. Gofumpt is a bit stricter than gofmt, allowing us to standardize formatting even further. The gci formatter ensures that import statements are sorted and grouped deterministically in a consistent manner.

https://golangci-lint.run/usage/formatters/

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->



### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

