### PR TITLE
docs: move nolint directive to beginning of block

### DIFF
--- a/openfeature/resolution_error.go
+++ b/openfeature/resolution_error.go
@@ -119,9 +119,10 @@ func (e *ProviderInitError) Error() string {
 	return fmt.Sprintf("ProviderInitError: %s (code: %s)", e.Message, e.ErrorCode)
 }
 
+//nolint:staticcheck // Renaming these would be a breaking change
 var (
 	// ProviderNotReadyError signifies that an operation failed because the provider is in a NOT_READY state.
-	ProviderNotReadyError = errors.New("provider not yet initialized") //nolint:staticcheck // Renaming this would be a breaking change
+	ProviderNotReadyError = errors.New("provider not yet initialized")
 	// ProviderFatalError signifies that an operation failed because the provider is in a FATAL state.
-	ProviderFatalError = errors.New("provider is in an irrecoverable error state") //nolint:staticcheck // Renaming this would be a breaking change
+	ProviderFatalError = errors.New("provider is in an irrecoverable error state")
 )


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

The nolint directive currently displays as part of documentation, which should not happen. This PR fixes that.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->



### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

