### PR TITLE
test: don't defer t.Cleanup

### DIFF
--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -42,7 +42,7 @@ func hydratedMocksForClientTests(t *testing.T, expectedEvaluations int) clientMo
 // and appends them to the collection of any previously added hooks.
 // When new hooks are added, previously added hooks are not removed.
 func TestRequirement_1_2_1(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockHook := NewMockHook(ctrl)
@@ -60,7 +60,7 @@ func TestRequirement_1_2_1(t *testing.T) {
 // containing an immutable `domain` field or accessor of type string,
 // which corresponds to the `domain` value supplied during client creation.
 func TestRequirement_1_2_2(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	clientName := "test-client"
 
 	client := NewClient(clientName)
@@ -86,7 +86,7 @@ func TestRequirement_1_2_2(t *testing.T) {
 // If the value returned by the underlying provider implementation does not match the expected type,
 // it's to be considered abnormal execution, and the supplied `default value` should be returned.
 func TestRequirements_1_3(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	client := NewClient("test-client")
 
 	type requirements interface {
@@ -107,7 +107,7 @@ func TestRequirements_1_3(t *testing.T) {
 // `default value` (boolean | number | string | structure, required), `evaluation context` (optional),
 // and `evaluation options` (optional), which returns an `evaluation details` structure.
 func TestRequirement_1_4_1(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	client := NewClient("test-client")
 
 	type requirements interface {
@@ -158,7 +158,7 @@ var objectValue = map[string]any{"foo": 1, "bar": true, "baz": "buz"}
 // contain the value of the `reason` field in the `flag resolution` structure returned
 // by the configured `provider`, if the field is set.
 func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	flagKey := "foo"
 
@@ -297,7 +297,7 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 // The `evaluation details` structure's `flag key` field MUST contain the `flag key`
 // argument passed to the detailed flag evaluation method.
 func TestRequirement_1_4_4(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	flagKey := "foo"
 	t.Run("BooleanValueDetails", func(t *testing.T) {
 		mocks := hydratedMocksForClientTests(t, 1)
@@ -418,7 +418,7 @@ func TestRequirement_1_4_4(t *testing.T) {
 // In cases of abnormal execution, the `evaluation details` structure's
 // `error code` field MUST contain an `error code`.
 func TestRequirement_1_4_7(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	mocks := hydratedMocksForClientTests(t, 1)
 	client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 
@@ -446,7 +446,7 @@ func TestRequirement_1_4_7(t *testing.T) {
 // In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field
 // in the `evaluation details` SHOULD indicate an error.
 func TestRequirement_1_4_8(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	mocks := hydratedMocksForClientTests(t, 1)
 	client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 	mocks.providerAPI.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -483,7 +483,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("Boolean", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -517,7 +517,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	})
 
 	t.Run("String", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -551,7 +551,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	})
 
 	t.Run("Float", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 
@@ -584,7 +584,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	})
 
 	t.Run("Int", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 		var defaultValue int64 = 3
@@ -616,7 +616,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	})
 
 	t.Run("Object", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 		type obj struct {
@@ -660,7 +660,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 // In cases of abnormal execution, the `evaluation details` structure's `error message` field MAY contain a
 // string containing additional details about the nature of the error.
 func TestRequirement_1_4_12(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	errMessage := "error forced by test"
 
@@ -698,7 +698,7 @@ func TestRequirement_1_4_13(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("No Metadata", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mocks := hydratedMocksForClientTests(t, 1)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -724,7 +724,7 @@ func TestRequirement_1_4_13(t *testing.T) {
 	})
 
 	t.Run("Metadata present", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mocks := hydratedMocksForClientTests(t, 1)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -979,7 +979,7 @@ func TestFlattenContext(t *testing.T) {
 // TestBeforeHookNilContext asserts that when a Before hook returns a nil EvaluationContext it doesn't overwrite the
 // existing EvaluationContext
 func TestBeforeHookNilContext(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	hookNilContext := UnimplementedHook{}
 
@@ -999,7 +999,7 @@ func TestBeforeHookNilContext(t *testing.T) {
 }
 
 func TestErrorCodeFromProviderReturnedInEvaluationDetails(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	generalErrorCode := GeneralCode
 
@@ -1029,7 +1029,7 @@ func TestErrorCodeFromProviderReturnedInEvaluationDetails(t *testing.T) {
 }
 
 func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	variant := "variant1"
 	reason := TargetingMatchReason
@@ -1200,7 +1200,7 @@ func TestRequirement_1_7_1(t *testing.T) {
 // The client's provider status accessor MUST indicate READY if the initialize function of the associated provider
 // terminates normally.
 func TestRequirement_1_7_2(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	if GetApiInstance().GetNamedClient(t.Name()).State() != NotReadyState {
 		t.Fatalf("expected client to report NOT READY state")
@@ -1228,7 +1228,7 @@ func TestRequirement_1_7_2(t *testing.T) {
 // The client's provider status accessor MUST indicate ERROR if the initialize function of the associated provider
 // terminates abnormally
 func TestRequirement_1_7_3(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	provider := struct {
 		FeatureProvider
 		StateHandler
@@ -1252,7 +1252,7 @@ func TestRequirement_1_7_3(t *testing.T) {
 // The client's provider status accessor MUST indicate FATAL if the initialize function of the associated provider
 // terminates abnormally and indicates error code PROVIDER_FATAL.
 func TestRequirement_1_7_4(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	provider := struct {
 		FeatureProvider
 		StateHandler
@@ -1277,7 +1277,7 @@ func TestRequirement_1_7_4(t *testing.T) {
 // The client's provider status accessor MUST indicate FATAL if the initialize function of the associated provider
 // terminates abnormally and indicates error code PROVIDER_FATAL.
 func TestRequirement_1_7_5(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	provider := struct {
 		FeatureProvider
 		StateHandler
@@ -1302,7 +1302,7 @@ func TestRequirement_1_7_5(t *testing.T) {
 // The client MUST default, run error hooks, and indicate an error if flag resolution is attempted while the provider
 // is in NOT_READY.
 func TestRequirement_1_7_6(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	ctrl := gomock.NewController(t)
 	mockHook := NewMockHook(ctrl)
@@ -1347,7 +1347,7 @@ func TestRequirement_1_7_6(t *testing.T) {
 // The client MUST default, run error hooks, and indicate an error if flag resolution is attempted while the provider
 // is in FATAL.
 func TestRequirement_1_7_7(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	provider := struct {
 		FeatureProvider
 		StateHandler
@@ -1402,7 +1402,7 @@ func TestRequirement_5_1_5(t *testing.T) {
 
 // If the provider emits an event, the value of the client's provider status MUST be updated accordingly.
 func TestRequirement_5_3_5(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	eventually(t, func() bool {
 		return GetApiInstance().GetClient().State() == NotReadyState

--- a/openfeature/evaluation_context_test.go
+++ b/openfeature/evaluation_context_test.go
@@ -42,7 +42,7 @@ func TestRequirement_3_1_2(t *testing.T) {
 
 // The API, Client and invocation MUST have a method for supplying `evaluation context`.
 func TestRequirement_3_2_1(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	t.Run("API MUST have a method for supplying `evaluation context`", func(t *testing.T) {
 		SetEvaluationContext(EvaluationContext{})
@@ -87,7 +87,7 @@ func TestRequirement_3_2_1(t *testing.T) {
 // Evaluation context MUST be merged in the order: API (global) - transaction - client - invocation,
 // with duplicate values being overwritten.
 func TestRequirement_3_2_2(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	apiEvalCtx := EvaluationContext{

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -51,7 +51,7 @@ func TestEventHandler_RegisterUnregisterEventProvider(t *testing.T) {
 // the associated client and API event handlers MUST run.
 func TestEventHandler_Eventing(t *testing.T) {
 	t.Run("Simple API level event", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -115,7 +115,7 @@ func TestEventHandler_Eventing(t *testing.T) {
 	})
 
 	t.Run("Simple Client level event", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -192,7 +192,7 @@ func TestEventHandler_Eventing(t *testing.T) {
 // Requirement 5.1.3 When a provider signals the occurrence of a particular event,
 // event handlers on clients which are not associated with that provider MUST NOT run.
 func TestEventHandler_clientAssociation(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	eventingImpl := &ProviderEventing{
 		c: make(chan Event, 1),
@@ -253,7 +253,7 @@ func TestEventHandler_clientAssociation(t *testing.T) {
 
 // Requirement 5.2.5 If a handler function terminates abnormally, other handler functions MUST run.
 func TestEventHandler_ErrorHandling(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	eventing := &ProviderEventing{
 		c: make(chan Event, 1),
@@ -328,7 +328,7 @@ func TestEventHandler_ErrorHandling(t *testing.T) {
 // Requirement 5.3.1 If the provider's initialize function terminates normally, PROVIDER_READY handlers MUST run.
 func TestEventHandler_InitOfProvider(t *testing.T) {
 	t.Run("for default provider in global handler scope", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -363,7 +363,7 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 	})
 
 	t.Run("for default provider with unassociated client handler", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -399,7 +399,7 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 	})
 
 	t.Run("for named provider in client scope", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -436,7 +436,7 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 	})
 
 	t.Run("no callback for named provider with no associations", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -477,7 +477,7 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 // Requirement 5.3.2 If the provider's initialize function terminates abnormally, PROVIDER_ERROR handlers MUST run.
 func TestEventHandler_InitOfProviderError(t *testing.T) {
 	t.Run("for default provider in global scope", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -513,7 +513,7 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 	})
 
 	t.Run("for default provider with unassociated client handler", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -551,7 +551,7 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 	})
 
 	t.Run("for named provider in client scope", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -589,7 +589,7 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 	})
 
 	t.Run("no callback for named provider with no associations", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -630,7 +630,7 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 // Requirement 5.3.3 PROVIDER_READY handlers attached after the provider is already in a ready state MUST run immediately.
 func TestEventHandler_ProviderReadiness(t *testing.T) {
 	t.Run("for api level under default provider", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event),
@@ -665,7 +665,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 	})
 
 	t.Run("for domain associated handler", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event),
@@ -702,7 +702,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 	})
 
 	t.Run("for unassociated handler from default", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event),
@@ -738,7 +738,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 	})
 
 	t.Run("no event if provider is not ready", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		notReadyEventingProvider := struct {
 			FeatureProvider
@@ -776,7 +776,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 	})
 
 	t.Run("no event if subscribed for some other event", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		readyEventingProvider := struct {
 			FeatureProvider
@@ -818,7 +818,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 // provider is already in the associated state, MUST run immediately
 func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	t.Run("ready handler runs when provider ready", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -852,7 +852,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("error handler runs when provider error", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -887,7 +887,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("stale handler runs when provider stale", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -922,7 +922,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("non-ready handler does not run when provider ready", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -958,7 +958,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("non-error handler does not run when provider error", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -1001,7 +1001,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("non-stale handler does not run when provider stale", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -1047,7 +1047,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 // non-spec bound validations
 
 func TestEventHandler_multiSubs(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	eventingImpl := &ProviderEventing{
 		c: make(chan Event, 1),

--- a/openfeature/hooks_test.go
+++ b/openfeature/hooks_test.go
@@ -149,7 +149,7 @@ func TestRequirement_4_2_2_3(t *testing.T) {
 // The `before` stage MUST run before flag resolution occurs. It accepts a `hook context` (required) and
 // `hook hints` (optional) as parameters and returns either an `evaluation context` or nothing.
 func TestRequirement_4_3_2(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	t.Run("before stage MUST run before flag resolution occurs", func(t *testing.T) {
@@ -197,7 +197,7 @@ func TestRequirement_4_3_2(t *testing.T) {
 
 // Any `evaluation context` returned from a `before` hook MUST be passed to subsequent `before` hooks (via `HookContext`).
 func TestRequirement_4_3_3(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockProvider := NewMockFeatureProvider(ctrl)
@@ -257,7 +257,7 @@ func TestRequirement_4_3_3(t *testing.T) {
 // `evaluation context` in the following order:
 // before-hook (highest precedence), invocation, client, api (lowest precedence).
 func TestRequirement_4_3_4(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockProvider := NewMockFeatureProvider(ctrl)
@@ -334,7 +334,7 @@ func TestRequirement_4_3_5(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	t.Run("after hook MUST run after flag resolution occurs", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -390,7 +390,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("error hook MUST run when errors are encountered in the before stage", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -415,7 +415,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 	})
 
 	t.Run("error hook MUST run when errors are encountered during flag evaluation", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -448,7 +448,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 	})
 
 	t.Run("error hook MUST run when errors are encountered during flag evaluation", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -499,7 +499,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("finally hook MUST run after the before & after stages", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -525,7 +525,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 	})
 
 	t.Run("finally hook MUST run after the error stage", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -565,7 +565,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 
 // The API, Client, Provider and invocation MUST have a method for registering hooks
 func TestRequirement_4_4_1(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	t.Run("API MUST have a method for registering hooks", func(t *testing.T) {
@@ -637,7 +637,7 @@ func TestRequirement_4_4_2(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("before, after & finally hooks MUST be evaluated in the following order", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mockAPIHook := NewMockHook(ctrl)
 		AddHooks(mockAPIHook)
@@ -686,7 +686,7 @@ func TestRequirement_4_4_2(t *testing.T) {
 	})
 
 	t.Run("error hooks MUST be evaluated in the following order", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		mockAPIHook := NewMockHook(ctrl)
 		AddHooks(mockAPIHook)
@@ -758,7 +758,7 @@ func TestRequirement_4_4_6(t *testing.T) {
 	t.Run(
 		"if an error occurs during the evaluation of before hooks, any remaining before hooks MUST NOT be invoked",
 		func(t *testing.T) {
-			defer t.Cleanup(initSingleton)
+			t.Cleanup(initSingleton)
 
 			mockHook1 := NewMockHook(ctrl)
 			mockHook2 := NewMockHook(ctrl)
@@ -792,7 +792,7 @@ func TestRequirement_4_4_6(t *testing.T) {
 	t.Run(
 		"if an error occurs during the evaluation of after hooks, any remaining after hooks MUST NOT be invoked",
 		func(t *testing.T) {
-			defer t.Cleanup(initSingleton)
+			t.Cleanup(initSingleton)
 
 			mockHook1 := NewMockHook(ctrl)
 			mockHook2 := NewMockHook(ctrl)
@@ -829,7 +829,7 @@ func TestRequirement_4_4_6(t *testing.T) {
 
 // If an error occurs in the `before` hooks, the default value MUST be returned.
 func TestRequirement_4_4_7(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	flagKey := "foo"
@@ -881,7 +881,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("hook hints must be passed to before, after & finally hooks", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
 		mockProvider.EXPECT().Metadata().AnyTimes()
@@ -910,7 +910,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 	})
 
 	t.Run("hook hints must be passed to error hooks", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 		mockHook := NewMockHook(ctrl)
 
 		mockProvider := NewMockFeatureProvider(ctrl)

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -14,7 +14,7 @@ import (
 // The `API`, and any state it maintains SHOULD exist as a global singleton,
 // even in cases wherein multiple versions of the `API` are present at runtime.
 func TestRequirement_1_1_1(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	ctrl := gomock.NewController(t)
 	mockProvider := NewMockFeatureProvider(ctrl)
@@ -37,7 +37,7 @@ func TestRequirement_1_1_1(t *testing.T) {
 // The `API` MUST provide a function to set the default `provider`,
 // which accepts an API-conformant `provider` implementation.
 func TestRequirement_1_1_2_1(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockProvider := NewMockFeatureProvider(ctrl)
@@ -58,7 +58,7 @@ func TestRequirement_1_1_2_1(t *testing.T) {
 // to resolve flag values.
 func TestRequirement_1_1_2_2(t *testing.T) {
 	t.Run("default provider", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		provider, initSem, _ := setupProviderWithSemaphores()
 
@@ -81,7 +81,7 @@ func TestRequirement_1_1_2_2(t *testing.T) {
 	})
 
 	t.Run("named provider", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		provider, initSem, _ := setupProviderWithSemaphores()
 
@@ -110,7 +110,7 @@ func TestRequirement_1_1_2_2(t *testing.T) {
 // longer being used to resolve flag values.
 func TestRequirement_1_1_2_3(t *testing.T) {
 	t.Run("default provider", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		provider, initSem, shutdownSem := setupProviderWithSemaphores()
 
@@ -144,7 +144,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 	})
 
 	t.Run("named provider", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		provider, initSem, shutdownSem := setupProviderWithSemaphores()
 
@@ -180,7 +180,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 	})
 
 	t.Run("ignore shutdown for multiple references - default bound", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		// setup
 		provider, _, shutdownSem := setupProviderWithSemaphores()
@@ -216,7 +216,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 	})
 
 	t.Run("ignore shutdown for multiple references - domain client bound", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		// setup
 		providerA, _, shutdownSemA := setupProviderWithSemaphores()
@@ -256,7 +256,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 
 // The API SHOULD provide functions to set a provider and wait for the initialize function to return or throw.
 func TestRequirement_1_1_2_4(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	t.Run("default provider", func(t *testing.T) {
 		// given - a provider with state handling capability, with substantial initializing delay
@@ -398,7 +398,7 @@ func TestRequirement_1_1_2_4(t *testing.T) {
 // The `API` MUST provide a function to bind a given `provider` to one or more client `domain`s.
 // If the client-domain already has a bound provider, it is overwritten with the new mapping.
 func TestRequirement_1_1_3(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	// Setup
 
@@ -474,7 +474,7 @@ func TestRequirement_1_1_3(t *testing.T) {
 // and appends them to the collection of any previously added hooks. When new hooks are added,
 // previously added hooks are not removed.
 func TestRequirement_1_1_4(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockHook := NewMockHook(ctrl)
@@ -489,7 +489,7 @@ func TestRequirement_1_1_4(t *testing.T) {
 
 // The API MUST provide a function for retrieving the metadata field of the configured `provider`.
 func TestRequirement_1_1_5(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	t.Run("default provider", func(t *testing.T) {
 		defaultProvider := NoopProvider{}
@@ -519,7 +519,7 @@ func TestRequirement_1_1_5(t *testing.T) {
 // The `API` MUST provide a function for creating a `client` which accepts the following options:
 // - domain (optional): A logical string identifier for the client.
 func TestRequirement_1_1_6(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	t.Run("client from direct invocation", func(t *testing.T) {
 		client := NewClient("test-client")
@@ -545,7 +545,7 @@ func TestRequirement_1_1_6(t *testing.T) {
 
 // The client creation function MUST NOT throw, or otherwise abnormally terminate.
 func TestRequirement_1_1_7(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	type clientCreationFunc func(name string) *Client
 
 	// asserting that our NewClient method matches this signature is enough to deduce that no error is returned
@@ -556,7 +556,7 @@ func TestRequirement_1_1_7(t *testing.T) {
 
 // The API MUST define a mechanism to propagate a shutdown request to active providers.
 func TestRequirement_1_6_1(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	provider, initSem, shutdownSem := setupProviderWithSemaphores()
 
@@ -589,7 +589,7 @@ func TestRequirement_EventCompliance(t *testing.T) {
 	// The client MUST provide a function for associating handler functions with a particular provider event type.
 	// The API and client MUST provide a function allowing the removal of event handlers.
 	t.Run("requirement_5_2_1 & requirement_5_2_1", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		clientName := "OFClient"
 
@@ -644,7 +644,7 @@ func TestRequirement_EventCompliance(t *testing.T) {
 
 	// The API MUST provide a function for associating handler functions with a particular provider event type.
 	t.Run("requirement_5_2_2 & requirement_5_2_1", func(t *testing.T) {
-		defer t.Cleanup(initSingleton)
+		t.Cleanup(initSingleton)
 
 		// adding handlers
 		AddHandler(ProviderReady, &h1)
@@ -700,7 +700,7 @@ func TestRequirement_EventCompliance(t *testing.T) {
 
 // If there is no client domain bound provider, then return the default provider
 func TestDefaultClientUsage(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	ctrl := gomock.NewController(t)
 	defaultProvider := NewMockFeatureProvider(ctrl)
@@ -720,7 +720,7 @@ func TestDefaultClientUsage(t *testing.T) {
 }
 
 func TestLateBindingOfDefaultProvider(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 	// we are expecting
 	expectedResultUnboundProvider := "default-value-from-unbound-provider"
 	expectedResultFromLateDefaultProvider := "value-from-late-default-provider"
@@ -763,7 +763,7 @@ func TestLateBindingOfDefaultProvider(t *testing.T) {
 
 // Nil providers are not accepted for default and named providers
 func TestForNilProviders(t *testing.T) {
-	defer t.Cleanup(initSingleton)
+	t.Cleanup(initSingleton)
 
 	err := SetProvider(nil)
 	if err == nil {


### PR DESCRIPTION
The `defer` is redundant, because `t.Cleanup` already ensures that the function is not called until after the test is done.

https://pkg.go.dev/testing#T.Cleanup
> Cleanup registers a function to be called when the test (or subtest) and all its subtests complete. Cleanup functions will be called in last added, first called order.