### PR TITLE
feat: expose generic resolution/evaluation details structs

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -148,30 +148,24 @@ type EvaluationDetails struct {
 	ResolutionDetail
 }
 
-type BooleanEvaluationDetails struct {
-	Value bool
+// GenericEvaluationDetails represents the result of the flag evaluation process.
+type GenericEvaluationDetails[T any] struct {
+	Value T
 	EvaluationDetails
 }
 
-type StringEvaluationDetails struct {
-	Value string
-	EvaluationDetails
-}
-
-type FloatEvaluationDetails struct {
-	Value float64
-	EvaluationDetails
-}
-
-type IntEvaluationDetails struct {
-	Value int64
-	EvaluationDetails
-}
-
-type InterfaceEvaluationDetails struct {
-	Value any
-	EvaluationDetails
-}
+type (
+	// BooleanEvaluationDetails represents the result of the flag evaluation process for boolean flags.
+	BooleanEvaluationDetails = GenericEvaluationDetails[bool]
+	// StringEvaluationDetails represents the result of the flag evaluation process for string flags.
+	StringEvaluationDetails = GenericEvaluationDetails[string]
+	// FloatEvaluationDetails represents the result of the flag evaluation process for float64 flags.
+	FloatEvaluationDetails = GenericEvaluationDetails[float64]
+	// IntEvaluationDetails represents the result of the flag evaluation process for int64 flags.
+	IntEvaluationDetails = GenericEvaluationDetails[int64]
+	// InterfaceEvaluationDetails represents the result of the flag evaluation process for Object flags.
+	InterfaceEvaluationDetails = GenericEvaluationDetails[any]
+)
 
 type ResolutionDetail struct {
 	Variant      string

--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -126,8 +126,6 @@ func (s NoopEventHandler) EventChannel() <-chan Event {
 // ProviderResolutionDetail is a structure which contains a subset of the fields defined in the EvaluationDetail,
 // representing the result of the provider's flag resolution process
 // see https://github.com/open-feature/spec/blob/main/specification/types.md#resolution-details
-// N.B we could use generics but to support older versions of go for now we will have type specific resolution
-// detail
 type ProviderResolutionDetail struct {
 	ResolutionError ResolutionError
 	Reason          Reason
@@ -156,35 +154,24 @@ func (p ProviderResolutionDetail) Error() error {
 	return errors.New(p.ResolutionError.Error())
 }
 
-// BoolResolutionDetail provides a resolution detail with boolean type
-type BoolResolutionDetail struct {
-	Value bool
+// GenericResolutionDetail represents the result of the provider's flag resolution process.
+type GenericResolutionDetail[T any] struct {
+	Value T
 	ProviderResolutionDetail
 }
 
-// StringResolutionDetail provides a resolution detail with string type
-type StringResolutionDetail struct {
-	Value string
-	ProviderResolutionDetail
-}
-
-// FloatResolutionDetail provides a resolution detail with float64 type
-type FloatResolutionDetail struct {
-	Value float64
-	ProviderResolutionDetail
-}
-
-// IntResolutionDetail provides a resolution detail with int64 type
-type IntResolutionDetail struct {
-	Value int64
-	ProviderResolutionDetail
-}
-
-// InterfaceResolutionDetail provides a resolution detail with any type
-type InterfaceResolutionDetail struct {
-	Value any
-	ProviderResolutionDetail
-}
+type (
+	// BoolResolutionDetail represents the result of the provider's flag resolution process for boolean flags.
+	BoolResolutionDetail = GenericResolutionDetail[bool]
+	// StringResolutionDetail represents the result of the provider's flag resolution process for string flags.
+	StringResolutionDetail = GenericResolutionDetail[string]
+	// FloatResolutionDetail represents the result of the provider's flag resolution process for float64 flags.
+	FloatResolutionDetail = GenericResolutionDetail[float64]
+	// IntResolutionDetail represents the result of the provider's flag resolution process for int64 flags.
+	IntResolutionDetail = GenericResolutionDetail[int64]
+	// InterfaceResolutionDetail represents the result of the provider's flag resolution process for Object flags.
+	InterfaceResolutionDetail = GenericResolutionDetail[any]
+)
 
 // Metadata provides provider name
 type Metadata struct {


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

We can introduce generic versions of the ResolutionDetail and EvaluationDetails structs without a breaking change by using type aliases. These generic structs can help provider authors and application authors write more modular code.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->



### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

