### PR TITLE
feat: add error wrapping support to ResolutionError

### DIFF
--- a/openfeature/resolution_error.go
+++ b/openfeature/resolution_error.go
@@ -69,11 +69,8 @@ func NewFlagNotFoundResolutionError(msg string) ResolutionError {
 // NewParseErrorResolutionError constructs a resolution error with code PARSE_ERROR
 //
 // Explanation - An error was encountered parsing data, such as a flag configuration.
-func NewParseErrorResolutionError(msg string) ResolutionError {
-	return ResolutionError{
-		code:    ParseErrorCode,
-		message: msg,
-	}
+func NewParseErrorResolutionError(msg string, errs ...error) ResolutionError {
+	return newResolutionError(ParseErrorCode, msg, errs...)
 }
 
 // NewTypeMismatchResolutionError constructs a resolution error with code TYPE_MISMATCH
@@ -110,6 +107,11 @@ func NewInvalidContextResolutionError(msg string) ResolutionError {
 //
 // Explanation - The error was for a reason not enumerated above.
 func NewGeneralResolutionError(msg string, errs ...error) ResolutionError {
+	return newResolutionError(GeneralCode, msg, errs...)
+}
+
+// newResolutionError is a helper to create a ResolutionError with an optional original error.
+func newResolutionError(code ErrorCode, msg string, errs ...error) ResolutionError {
 	var originalErr error
 	switch len(errs) {
 	case 0:
@@ -120,7 +122,7 @@ func NewGeneralResolutionError(msg string, errs ...error) ResolutionError {
 		originalErr = errors.Join(errs...)
 	}
 	return ResolutionError{
-		code:        GeneralCode,
+		code:        code,
 		message:     msg,
 		originalErr: originalErr,
 	}

--- a/openfeature/resolution_error_test.go
+++ b/openfeature/resolution_error_test.go
@@ -8,29 +8,40 @@ import (
 )
 
 func TestResolutionErrorWithOriginal(t *testing.T) {
-	err := NewGeneralResolutionError("flag not found", io.ErrNoProgress)
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"general", NewGeneralResolutionError("flag not found", io.ErrNoProgress)},
+		{"parse", NewParseErrorResolutionError("flag not found", io.ErrNoProgress)},
+	}
 
-	t.Run("wraps original error", func(t *testing.T) {
-		if !errors.Is(err, io.ErrNoProgress) {
-			t.Errorf("expected error to wrap %v", io.ErrNoProgress)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.err
+			t.Run("wraps original error", func(t *testing.T) {
+				if !errors.Is(err, io.ErrNoProgress) {
+					t.Errorf("expected error to wrap %v", io.ErrNoProgress)
+				}
+			})
 
-	t.Run("does not match unrelated error", func(t *testing.T) {
-		if errors.Is(err, io.EOF) {
-			t.Errorf("expected error to not match %v", io.EOF)
-		}
-	})
+			t.Run("does not match unrelated error", func(t *testing.T) {
+				if errors.Is(err, io.EOF) {
+					t.Errorf("expected error to not match %v", io.EOF)
+				}
+			})
 
-	t.Run("contains expected message", func(t *testing.T) {
-		if !strings.Contains(err.Error(), "flag not found") {
-			t.Errorf("expected message to contain %q, got %q", "flag not found", err.Error())
-		}
-	})
+			t.Run("contains expected message", func(t *testing.T) {
+				if !strings.Contains(err.Error(), "flag not found") {
+					t.Errorf("expected message to contain %q, got %q", "flag not found", err.Error())
+				}
+			})
 
-	t.Run("unwrap returns original", func(t *testing.T) {
-		if unwrapped := errors.Unwrap(err); unwrapped != io.ErrNoProgress {
-			t.Errorf("expected unwrap to return %v, got %v", io.ErrNoProgress, unwrapped)
-		}
-	})
+			t.Run("unwrap returns original", func(t *testing.T) {
+				if unwrapped := errors.Unwrap(err); unwrapped != io.ErrNoProgress {
+					t.Errorf("expected unwrap to return %v, got %v", io.ErrNoProgress, unwrapped)
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
## This PR

- add the ability to preserve original errors in general ResolutionError. This enables providers to wrap underlying errors while maintaining backward compatibility, allowing callers to use `errors.Is()` and `errors.As()` for error inspection.

## Related Issues
#437 