### PR TITLE
fix(multi-provider): correct provider state tracking and improve robustness

### DIFF
--- a/openfeature/multi/comparison_strategy.go
+++ b/openfeature/multi/comparison_strategy.go
@@ -23,7 +23,7 @@ type Comparator func(values []any) bool
 // there is a comparison failure -- prior to returning a default result. The [Comparator] parameter is optional and nil
 // can be passed as long as ObjectEvaluation is never called with objects that are not comparable. The custom [Comparator]
 // will only be used for [of.FeatureProvider.ObjectEvaluation] if set. If [of.FeatureProvider.ObjectEvaluation] is
-// called without setting a [Comparator], and the returned object(s) are not comparable, then a panic will occur.
+// called without setting a [Comparator], and the returned object(s) are not comparable, then an error will occur.
 func newComparisonStrategy(providers []*NamedProvider, fallbackProvider of.FeatureProvider, comparator Comparator) StrategyFn[FlagTypes] {
 	return evaluateComparison[FlagTypes](providers, fallbackProvider, comparator)
 }
@@ -240,10 +240,9 @@ func evaluateComparison[T FlagTypes](providers []*NamedProvider, fallbackProvide
 		}
 
 		defaultResult := BuildDefaultResult(StrategyComparison, defaultValue, errors.New("no fallback provider configured"))
-		mergeFlagMeta(defaultResult.FlagMetadata, metadata)
+		defaultResult.FlagMetadata = mergeFlagMeta(defaultResult.FlagMetadata, metadata)
 		defaultResult.FlagMetadata[MetadataFallbackUsed] = false
 		defaultResult.FlagMetadata[MetadataIsDefaultValue] = true
-
 		return defaultResult
 	}
 }

--- a/openfeature/multi/strategies.go
+++ b/openfeature/multi/strategies.go
@@ -15,8 +15,8 @@ const (
 	// This is executed sequentially, and not in parallel. Any returned errors from a provider other than flag not found
 	// will result in a default response with a set error.
 	StrategyFirstMatch EvaluationStrategy = "strategy-first-match"
-	// StrategyFirstSuccess returns the result of the First [of.FeatureProvider] whose response that is not an error.
-	// This is very similar to [StrategyFirstMatch], but does not raise errors. This executed sequentially.
+	// StrategyFirstSuccess returns the result of the first [of.FeatureProvider] whose response that is not an error.
+	// This is very similar to [StrategyFirstMatch], but does not raise errors. This is executed sequentially.
 	StrategyFirstSuccess EvaluationStrategy = "strategy-first-success"
 	// StrategyComparison returns a response of all [of.FeatureProvider] instances in agreement. All providers are
 	// called in parallel and then the results of each non-error result are compared to each other. If all responses


### PR DESCRIPTION
## This PR

- fix critical bug where provider state updates used wrong field (e.ProviderName instead of e.providerName), causing state tracking to fail when multiple providers of the same type were registered with different unique names
- fix metadata merge not being assigned in comparison strategy when no fallback provider is configured
- add buffering to outbound event channel to prevent blocking
- adjust code comments
- add debug logging when Shutdown() called on uninitialized provider