### PR TITLE
feat: Add targeting match split reason

### DIFF
--- a/openfeature/provider.go
+++ b/openfeature/provider.go
@@ -11,6 +11,8 @@ const (
 	DefaultReason Reason = "DEFAULT"
 	// TargetingMatchReason - the resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting.
 	TargetingMatchReason Reason = "TARGETING_MATCH"
+	// TargetingMatchSplitReason - the resolved value was the result of a dynamic evaluation that resolves to a percentage split.
+	TargetingMatchSplitReason Reason = "TARGETING_MATCH_SPLIT"
 	// SplitReason - the resolved value was the result of pseudorandom assignment.
 	SplitReason Reason = "SPLIT"
 	// DisabledReason - the resolved value was the result of the flag being disabled in the management system.


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds TARGETING_MATCH_SPLIT reason

### Notes
<!-- any additional notes for this PR -->

This reason is used in go-feature-flag lib: https://github.com/thomaspoignant/go-feature-flag/blob/916ae7747b17a62dc904ee6a5f02a57c7147da25/modules/core/flag/resolution_reason.go#L15