### PR TITLE
chore: update release please pipeline to support release immutability

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,14 +10,17 @@ env:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to create release commit
+      pull-requests: write # to create release PR
+      issues: write # to create labels
+
     # Release-please creates a PR that tracks all changes
     steps:
-      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
-          command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
-          default-branch: main
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       release_tag_name: ${{ steps.release.outputs.tag_name }}
@@ -35,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Install cyclonedx-gomod
         uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,14 +10,17 @@ env:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to create release commit
+      pull-requests: write # to create release PR
+      issues: write # to create labels
+
     # Release-please creates a PR that tracks all changes
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
-          command: manifest
           token: ${{secrets.GITHUB_TOKEN}}
-          default-branch: main
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       release_tag_name: ${{ steps.release.outputs.tag_name }}
@@ -35,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Install cyclonedx-gomod
         uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,8 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+release:
+  use_existing_draft: true
 sboms:
   - documents:
       - bom.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,13 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "signoff": "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>",
   "bootstrap-sha": "95df901b104dadc8902117c87d2e412d78d6a620",
   "packages": {
     ".": {
       "release-type": "go",
       "prerelease": false,
+      "draft": true,
+      "force-tag-creation": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": ["README.md"],


### PR DESCRIPTION
## This PR

Updates release-please-action to v4.4.1, introducing support for forced Git tag creation.

With this change, a draft release would be created as part of the release-please-action step. GoReleaser then picks up that draft, upload the necessary build artifacts, and complete the release process. This allows to enable GitHub release immutability.

<!-- add the description of the PR here -->

- Add explicit contents: write, pull-requests: write, and issues: write permissions
- Enable `force-tag-creation: true` to precreate git release tag
- Enable `use_existing_draft: true` in goreleaser to reuse draft release
  created by release-please action
- Add signoff for commit attribution compliance

### Related Issues

#457
