### PR TITLE
chore: make govulncheck non-blocking

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - name: Run govulncheck
+        continue-on-error: true
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
       - name: Install Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5


### PR DESCRIPTION
## Summary
- Makes govulncheck advisory (non-blocking) in CI via `continue-on-error: true`
- Vulncheck results still visible on PRs but won't block merges
- Libraries shouldn't be blocked by transitive vuln issues with no available fix