### PR TITLE
fix(event_executor): update provider status before invoking API-level handlers

### DIFF
--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -297,29 +297,40 @@ func (e *eventExecutor) triggerEvent(event Event, handler FeatureProvider) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// first run API handlers
+	// Per OpenFeature spec requirement 5.3.5, the client's provider
+	// status MUST be updated BEFORE any event handlers (API-level or
+	// client-scoped) fire, so every handler — including API-level
+	// handlers that query client state — observes the new status.
+	// Write the state for every domain affected by this handler's
+	// provider reference first, then dispatch handlers.
+	isDefault := e.defaultProviderReference.equals(newProviderRef(handler))
+	namedDomains := make([]string, 0)
+	for domain, reference := range e.namedProviderReference {
+		if reference.equals(newProviderRef(handler)) {
+			namedDomains = append(namedDomains, domain)
+			e.states.Store(domain, stateFromEvent(event))
+		}
+	}
+	if isDefault {
+		e.states.Store(defaultDomain, stateFromEvent(event))
+	}
+
+	// first run API handlers (after state has been written above)
 	for _, c := range e.apiRegistry[event.EventType] {
 		e.executeHandler(*c, event)
 	}
 
-	// then run client handlers
-	for domain, reference := range e.namedProviderReference {
-		if !reference.equals(newProviderRef(handler)) {
-			continue
-		}
-
-		e.states.Store(domain, stateFromEvent(event))
+	// then run client handlers bound to a named domain matching this provider
+	for _, domain := range namedDomains {
 		for _, c := range e.scopedRegistry[domain].callbacks[event.EventType] {
 			e.executeHandler(*c, event)
 		}
 	}
 
-	if !e.defaultProviderReference.equals(newProviderRef(handler)) {
+	if !isDefault {
 		return
 	}
 
-	// handling the default provider
-	e.states.Store(defaultDomain, stateFromEvent(event))
 	// invoke default provider bound (no provider associated) handlers by filtering
 	for domain, registry := range e.scopedRegistry {
 		if _, ok := e.namedProviderReference[domain]; ok {

--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -297,22 +297,20 @@ func (e *eventExecutor) triggerEvent(event Event, handler FeatureProvider) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Per OpenFeature spec requirement 5.3.5, the client's provider
-	// status MUST be updated BEFORE any event handlers (API-level or
-	// client-scoped) fire, so every handler — including API-level
-	// handlers that query client state — observes the new status.
-	// Write the state for every domain affected by this handler's
-	// provider reference first, then dispatch handlers.
-	isDefault := e.defaultProviderReference.equals(newProviderRef(handler))
-	namedDomains := make([]string, 0)
+	// Per spec 5.3.5, write provider status BEFORE handlers run so every
+	// handler — including API-level — sees the new state.
+	handlerRef := newProviderRef(handler)
+	newState := stateFromEvent(event)
+	isDefault := e.defaultProviderReference.equals(handlerRef)
+	var namedDomains []string
 	for domain, reference := range e.namedProviderReference {
-		if reference.equals(newProviderRef(handler)) {
+		if reference.equals(handlerRef) {
 			namedDomains = append(namedDomains, domain)
-			e.states.Store(domain, stateFromEvent(event))
+			e.states.Store(domain, newState)
 		}
 	}
 	if isDefault {
-		e.states.Store(defaultDomain, stateFromEvent(event))
+		e.states.Store(defaultDomain, newState)
 	}
 
 	// first run API handlers (after state has been written above)

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -1557,3 +1557,123 @@ func TestEventHandler_ChannelClosure(t *testing.T) {
 	afterCount := eventCount.Load()
 	require.Equal(t, initialCount, afterCount, "goroutine processed events after channel closed - indicates channel closure not detected")
 }
+
+// Requirement 5.3.5: API and client handlers MUST observe the updated provider
+// status when they fire. Regression test for the ordering bug where API-level
+// handlers ran before e.states was written, so a handler that queried the
+// client's State during a ProviderReady callback would still see NotReadyState
+// (or, on a stale -> ready transition, the previous state).
+func TestEventHandler_StateUpdatedBeforeHandlersRun(t *testing.T) {
+	t.Run("API handler observes new state for default provider", func(t *testing.T) {
+		executor := newEventExecutor()
+
+		provider := struct {
+			FeatureProvider
+			EventHandler
+		}{
+			NoopProvider{},
+			&ProviderEventing{c: make(chan Event, 1)},
+		}
+		executor.registerDefaultProvider(provider)
+
+		observed := make(chan State, 1)
+		callback := func(EventDetails) {
+			observed <- executor.State(defaultDomain)
+		}
+		executor.AddHandler(ProviderReady, &callback)
+
+		executor.triggerEvent(Event{
+			ProviderName: provider.Metadata().Name,
+			EventType:    ProviderReady,
+		}, provider)
+
+		select {
+		case got := <-observed:
+			require.Equal(t, ReadyState, got,
+				"API handler must see ReadyState (state must be written before handlers run)")
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("API handler did not run")
+		}
+	})
+
+	t.Run("client handler observes new state for named provider", func(t *testing.T) {
+		executor := newEventExecutor()
+
+		defaultProvider := struct {
+			FeatureProvider
+			EventHandler
+		}{
+			NoopProvider{},
+			&ProviderEventing{c: make(chan Event, 1)},
+		}
+		executor.registerDefaultProvider(defaultProvider)
+
+		namedProvider := struct {
+			FeatureProvider
+			EventHandler
+		}{
+			NoopProvider{},
+			&ProviderEventing{c: make(chan Event, 1)},
+		}
+		const domain = "domainA"
+		executor.registerNamedEventingProvider(domain, namedProvider)
+
+		observed := make(chan State, 1)
+		callback := func(EventDetails) {
+			observed <- executor.State(domain)
+		}
+		executor.AddClientHandler(domain, ProviderError, &callback)
+
+		executor.triggerEvent(Event{
+			ProviderName: namedProvider.Metadata().Name,
+			EventType:    ProviderError,
+		}, namedProvider)
+
+		select {
+		case got := <-observed:
+			require.Equal(t, ErrorState, got,
+				"client handler must see ErrorState (state must be written before handlers run)")
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("client handler did not run")
+		}
+	})
+
+	t.Run("transition from stale to ready: handler observes ready, not stale", func(t *testing.T) {
+		executor := newEventExecutor()
+
+		provider := struct {
+			FeatureProvider
+			EventHandler
+		}{
+			NoopProvider{},
+			&ProviderEventing{c: make(chan Event, 1)},
+		}
+		executor.registerDefaultProvider(provider)
+
+		// Drive into stale first.
+		executor.triggerEvent(Event{
+			ProviderName: provider.Metadata().Name,
+			EventType:    ProviderStale,
+		}, provider)
+		require.Equal(t, StaleState, executor.State(defaultDomain))
+
+		observed := make(chan State, 1)
+		callback := func(EventDetails) {
+			observed <- executor.State(defaultDomain)
+		}
+		executor.AddHandler(ProviderReady, &callback)
+
+		executor.triggerEvent(Event{
+			ProviderName: provider.Metadata().Name,
+			EventType:    ProviderReady,
+		}, provider)
+
+		select {
+		case got := <-observed:
+			require.Equal(t, ReadyState, got,
+				"handler must see ReadyState after stale->ready transition, not the previous StaleState")
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("ready handler did not run")
+		}
+	})
+}

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func init() {
@@ -1564,16 +1565,13 @@ func TestEventHandler_ChannelClosure(t *testing.T) {
 // client's State during a ProviderReady callback would still see NotReadyState
 // (or, on a stale -> ready transition, the previous state).
 func TestEventHandler_StateUpdatedBeforeHandlersRun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
 	t.Run("API handler observes new state for default provider", func(t *testing.T) {
 		executor := newEventExecutor()
 
-		provider := struct {
-			FeatureProvider
-			EventHandler
-		}{
-			NoopProvider{},
-			&ProviderEventing{c: make(chan Event, 1)},
-		}
+		provider := NewMockFeatureProvider(ctrl)
 		executor.registerDefaultProvider(provider)
 
 		observed := make(chan State, 1)
@@ -1583,7 +1581,7 @@ func TestEventHandler_StateUpdatedBeforeHandlersRun(t *testing.T) {
 		executor.AddHandler(ProviderReady, &callback)
 
 		executor.triggerEvent(Event{
-			ProviderName: provider.Metadata().Name,
+			ProviderName: defaultDomain,
 			EventType:    ProviderReady,
 		}, provider)
 
@@ -1599,23 +1597,11 @@ func TestEventHandler_StateUpdatedBeforeHandlersRun(t *testing.T) {
 	t.Run("client handler observes new state for named provider", func(t *testing.T) {
 		executor := newEventExecutor()
 
-		defaultProvider := struct {
-			FeatureProvider
-			EventHandler
-		}{
-			NoopProvider{},
-			&ProviderEventing{c: make(chan Event, 1)},
-		}
+		defaultProvider := NewMockFeatureProvider(ctrl)
+		namedProvider := NewMockFeatureProvider(ctrl)
 		executor.registerDefaultProvider(defaultProvider)
-
-		namedProvider := struct {
-			FeatureProvider
-			EventHandler
-		}{
-			NoopProvider{},
-			&ProviderEventing{c: make(chan Event, 1)},
-		}
 		const domain = "domainA"
+
 		executor.registerNamedEventingProvider(domain, namedProvider)
 
 		observed := make(chan State, 1)
@@ -1625,7 +1611,7 @@ func TestEventHandler_StateUpdatedBeforeHandlersRun(t *testing.T) {
 		executor.AddClientHandler(domain, ProviderError, &callback)
 
 		executor.triggerEvent(Event{
-			ProviderName: namedProvider.Metadata().Name,
+			ProviderName: domain,
 			EventType:    ProviderError,
 		}, namedProvider)
 
@@ -1641,18 +1627,12 @@ func TestEventHandler_StateUpdatedBeforeHandlersRun(t *testing.T) {
 	t.Run("transition from stale to ready: handler observes ready, not stale", func(t *testing.T) {
 		executor := newEventExecutor()
 
-		provider := struct {
-			FeatureProvider
-			EventHandler
-		}{
-			NoopProvider{},
-			&ProviderEventing{c: make(chan Event, 1)},
-		}
+		provider := NewMockFeatureProvider(ctrl)
 		executor.registerDefaultProvider(provider)
 
 		// Drive into stale first.
 		executor.triggerEvent(Event{
-			ProviderName: provider.Metadata().Name,
+			ProviderName: defaultDomain,
 			EventType:    ProviderStale,
 		}, provider)
 		require.Equal(t, StaleState, executor.State(defaultDomain))
@@ -1664,7 +1644,7 @@ func TestEventHandler_StateUpdatedBeforeHandlersRun(t *testing.T) {
 		executor.AddHandler(ProviderReady, &callback)
 
 		executor.triggerEvent(Event{
-			ProviderName: provider.Metadata().Name,
+			ProviderName: defaultDomain,
 			EventType:    ProviderReady,
 		}, provider)
 


### PR DESCRIPTION
Fixes open-feature/go-sdk#493.

Per OpenFeature spec [requirement 5.3.5](https://github.com/open-feature/spec/blob/main/specification/sections/05-events.md#requirement-535):

> If the provider emits an event, the value of the client's provider status MUST be updated to the status associated with that event **before** the SDK invokes any event handlers for that event, so that handlers observe a consistent status.

`triggerEvent` previously dispatched API-level (global) handlers before calling `states.Store`, so a global handler that queried client state observed the stale status. Client-scoped handlers were fine — `states.Store` ran just before those.

## Fix

Collect the domain writes first (every named domain matching this provider, plus `defaultDomain` if the handler is the default provider), call `states.Store` for each, then dispatch API-level → named-domain → default-domain handlers in the same order as before. No change to handler ordering, just the state-write ordering.

## Test

`go test -tags testtools ./openfeature/...` clean.