### PR TITLE
fix: Fix internal tests not properly cleaning up/leaking goroutines. 

### DIFF
--- a/openfeature/context_aware_test.go
+++ b/openfeature/context_aware_test.go
@@ -97,6 +97,7 @@ func TestContextAwareInitialization(t *testing.T) {
 
 	// Create fresh API for isolated testing
 	exec := newEventExecutor()
+	defer exec.shutdown()
 	testAPI := newEvaluationAPI(exec)
 	api = testAPI
 	eventing = exec
@@ -235,6 +236,7 @@ func TestContextAwareShutdown(t *testing.T) {
 
 	// Create fresh API for isolated testing
 	exec := newEventExecutor()
+	defer exec.shutdown()
 	testAPI := newEvaluationAPI(exec)
 	api = testAPI
 	eventing = exec
@@ -297,6 +299,10 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	t.Run("shutdown with context affects all providers", func(t *testing.T) {
 		// Create fresh API for isolated testing
 		exec := newEventExecutor()
+		defer exec.shutdown()
+		// ShutdownWithContext below reinitializes the global event executor via
+		// initSingleton; shut that replacement down too so it doesn't leak.
+		defer func() { eventing.(*eventExecutor).shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -333,6 +339,10 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	t.Run("shutdown timeout handling", func(t *testing.T) {
 		// Create fresh API for isolated testing
 		exec := newEventExecutor()
+		defer exec.shutdown()
+		// ShutdownWithContext below reinitializes the global event executor via
+		// initSingleton; shut that replacement down too so it doesn't leak.
+		defer func() { eventing.(*eventExecutor).shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -375,6 +385,10 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	t.Run("backward compatibility with regular providers", func(t *testing.T) {
 		// Create fresh API for isolated testing
 		exec := newEventExecutor()
+		defer exec.shutdown()
+		// ShutdownWithContext below reinitializes the global event executor via
+		// initSingleton; shut that replacement down too so it doesn't leak.
+		defer func() { eventing.(*eventExecutor).shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -494,6 +508,7 @@ func TestContextPropagationFixes(t *testing.T) {
 
 	// Create fresh API for isolated testing
 	exec := newEventExecutor()
+	defer exec.shutdown()
 	testAPI := newEvaluationAPI(exec)
 	api = testAPI
 	eventing = exec
@@ -542,6 +557,7 @@ func TestContextPropagationFixes(t *testing.T) {
 	t.Run("shutdown respects context cancellation", func(t *testing.T) {
 		// Reset API
 		exec = newEventExecutor()
+		defer exec.shutdown()
 		testAPI = newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -731,6 +747,7 @@ func TestEdgeCases(t *testing.T) {
 
 	// Create fresh API for isolated testing
 	exec := newEventExecutor()
+	defer exec.shutdown()
 	testAPI := newEvaluationAPI(exec)
 	api = testAPI
 	eventing = exec
@@ -738,6 +755,7 @@ func TestEdgeCases(t *testing.T) {
 	t.Run("rapid provider switching", func(t *testing.T) {
 		// Reset API
 		exec = newEventExecutor()
+		defer exec.shutdown()
 		testAPI = newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -766,6 +784,7 @@ func TestEdgeCases(t *testing.T) {
 	t.Run("concurrent operations with different contexts", func(t *testing.T) {
 		// Reset API
 		exec = newEventExecutor()
+		defer exec.shutdown()
 		testAPI = newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec

--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -43,7 +43,11 @@ func newEventExecutor() *eventExecutor {
 		done:                   make(chan struct{}),
 	}
 
-	executor.startEventListener()
+	// The event listener goroutine is started lazily (see startEventListener),
+	// when the first event-emitting provider is registered. This avoids leaving
+	// a background goroutine running for consumers that merely import the SDK
+	// without registering an eventing provider.
+	// See https://github.com/open-feature/go-sdk/issues/471.
 	return &executor
 }
 
@@ -227,6 +231,10 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 		e.activeSubscriptions = append(e.activeSubscriptions, newProvider)
 
 		if v, ok := newProvider.featureProvider.(EventHandler); ok {
+			// Ensure the event listener is running now that an event-emitting
+			// provider produces events on eventChan (started once, lazily).
+			e.startEventListener()
+
 			e.wg.Add(1)
 			go func() {
 				defer e.wg.Done()
@@ -282,7 +290,11 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 	}
 }
 
-// startEventListener trigger the event listening of this executor
+// startEventListener triggers the event listening of this executor. It is
+// invoked lazily, the first time an event-emitting provider is registered, so
+// that importing the SDK without using eventing leaves no background goroutine
+// running (see https://github.com/open-feature/go-sdk/issues/471). The sync.Once
+// guard makes repeated calls safe and ensures a single listener per executor.
 func (e *eventExecutor) startEventListener() {
 	e.once.Do(func() {
 		e.wg.Add(1)
@@ -399,4 +411,3 @@ func (e *eventExecutor) shutdown() {
 		}
 	})
 }
-

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -31,6 +31,7 @@ func TestEventHandler_RegisterUnregisterEventProvider(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 		err := executor.registerDefaultProvider(eventingProvider)
 		if err != nil {
 			t.Fatal(err)
@@ -1216,6 +1217,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		err := executor.registerDefaultProvider(eventingProvider)
 		if err != nil {
@@ -1254,6 +1256,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		err := executor.registerDefaultProvider(eventingProvider)
 		if err != nil {
@@ -1297,6 +1300,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		err := executor.registerNamedEventingProvider("clientA", eventingProvider)
 		if err != nil {
@@ -1340,6 +1344,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		err := executor.registerNamedEventingProvider("clientA", eventingProvider)
 		if err != nil {
@@ -1372,6 +1377,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 func TestEventHandler_Registration(t *testing.T) {
 	t.Run("API handlers", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// Add multiple - ProviderReady
 		executor.AddHandler(ProviderReady, &h1)
@@ -1410,6 +1416,7 @@ func TestEventHandler_Registration(t *testing.T) {
 
 	t.Run("Client handlers", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// Add multiple - client a
 		executor.AddClientHandler("a", ProviderReady, &h1)
@@ -1447,6 +1454,7 @@ func TestEventHandler_Registration(t *testing.T) {
 func TestEventHandler_APIRemoval(t *testing.T) {
 	t.Run("API level removal", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// Add multiple - ProviderReady
 		executor.AddHandler(ProviderReady, &h1)
@@ -1500,6 +1508,7 @@ func TestEventHandler_APIRemoval(t *testing.T) {
 
 	t.Run("Client level removal", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// Add multiple - client a
 		executor.AddClientHandler("a", ProviderReady, &h1)
@@ -1557,6 +1566,7 @@ func TestEventHandler_APIRemoval(t *testing.T) {
 
 	t.Run("remove handlers that were not added", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// removal of non-added handlers shall not panic
 		executor.RemoveHandler(ProviderReady, &h1)
@@ -1578,6 +1588,7 @@ func TestEventHandler_ChannelClosure(t *testing.T) {
 	}
 
 	executor := newEventExecutor()
+	defer executor.shutdown()
 
 	err := executor.registerDefaultProvider(eventingProvider)
 	require.NoError(t, err)
@@ -1632,24 +1643,14 @@ func TestBasicShutdown(t *testing.T) {
 // TestNoGoroutineLeakWithMultipleProviders verifies that goroutine cleanup
 // works correctly even when multiple providers are registered.
 func TestNoGoroutineLeakWithMultipleProviders(t *testing.T) {
-	// Setup: shut down any existing goroutines from previous tests first
-	if eventing != nil {
-		eventing.(*eventExecutor).shutdown()
-	}
-	initSingleton()
+	// Start from a clean goroutine baseline and restore a working singleton
+	// afterwards (see startLeakTest).
+	startLeakTest(t)
 
-	defer goleak.VerifyNone(t,
-		// Ignore the new event executor's goroutines created by Shutdown() -> initSingleton()
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startListeningAndShutdownOld.func1"),
-	)
-
-	// Ensure we clean up the event executor at the end, including any reinitialized instance
-	defer func() {
-		if eventing != nil {
-			eventing.(*eventExecutor).shutdown()
-		}
-	}()
+	// Verify no goroutines leak. The shutdown below is registered after this so
+	// it runs first (defers are LIFO), stopping the executor before we verify.
+	defer goleak.VerifyNone(t)
+	defer shutdownEventing()
 
 	// Set default provider
 	defaultProvider := &ProviderEventing{c: make(chan Event, 1)}
@@ -1691,5 +1692,5 @@ func TestNoGoroutineLeakWithMultipleProviders(t *testing.T) {
 	// Shutdown cleans up all goroutines and reinitializes
 	Shutdown()
 
-	// goleak will verify no goroutines are leaked (except the new event executor)
+	// goleak will verify no goroutines are leaked
 }

--- a/openfeature/main_test.go
+++ b/openfeature/main_test.go
@@ -1,19 +1,61 @@
 package openfeature
 
 import (
+	"fmt"
 	"os"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
-// TestMain provides setup and teardown for the entire test suite
+// TestMain provides setup and teardown for the entire test suite. After the
+// tests run it shuts down the global event executor and then verifies that no
+// goroutines were leaked, guarding against regressions of the leak described in
+// https://github.com/open-feature/go-sdk/issues/471.
 func TestMain(m *testing.M) {
-	// Run tests
 	code := m.Run()
 
-	// Final cleanup: shut down the global event executor
-	if eventing != nil {
-		eventing.(*eventExecutor).shutdown()
+	if code == 0 {
+		// Shut down the global event executor so its background goroutine is
+		// stopped before we verify that nothing was leaked.
+		if eventing != nil {
+			eventing.(*eventExecutor).shutdown()
+		}
+
+		if err := goleak.Find(); err != nil {
+			fmt.Fprintf(os.Stderr, "goroutine leak detected: %v\n", err)
+			code = 1
+		}
 	}
 
 	os.Exit(code)
+}
+
+// startLeakTest prepares the global event executor for a goroutine-leak test.
+//
+// It shuts down the current executor and reinitializes a fresh one so the test
+// starts from a known-clean goroutine baseline regardless of what previous
+// tests left behind. It also registers a t.Cleanup that reinitializes the
+// singleton once more, restoring a working executor for subsequent tests after
+// the test's deferred goleak verification has run (deferred calls execute
+// before t.Cleanup callbacks).
+//
+// Leak tests should pair this with a deferred shutdown of the global executor
+// (registered after the goleak verification so it runs first), e.g.:
+//
+//	startLeakTest(t)
+//	defer goleak.VerifyNone(t)
+//	defer shutdownEventing()
+func startLeakTest(t *testing.T) {
+	t.Helper()
+	shutdownEventing()
+	initSingleton()
+	t.Cleanup(initSingleton)
+}
+
+// shutdownEventing shuts down the global event executor if one is set.
+func shutdownEventing() {
+	if eventing != nil {
+		eventing.(*eventExecutor).shutdown()
+	}
 }

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -1,9 +1,9 @@
 package openfeature
 
 import (
-	"context"
 	"errors"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -846,25 +846,14 @@ func expectTimeout(t *testing.T, ch <-chan any, receiveMsg string) {
 // TestNoGoroutineLeak verifies that the event executor's goroutine is properly
 // cleaned up after shutdown, preventing goroutine leaks.
 func TestNoGoroutineLeak(t *testing.T) {
-	// Setup: shut down any existing goroutines from previous tests first
-	if eventing != nil {
-		eventing.(*eventExecutor).shutdown()
-	}
-	initSingleton()
+	// Start from a clean goroutine baseline and restore a working singleton
+	// afterwards (see startLeakTest).
+	startLeakTest(t)
 
-	// Setup: capture initial goroutines after cleanup
-	defer goleak.VerifyNone(t,
-		// Ignore the new event executor's goroutines created by Shutdown() -> initSingleton()
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startListeningAndShutdownOld.func1"),
-	)
-
-	// Ensure we clean up the event executor at the end, including any reinitialized instance
-	defer func() {
-		if eventing != nil {
-			eventing.(*eventExecutor).shutdown()
-		}
-	}()
+	// Verify no goroutines leak. The shutdown below is registered after this so
+	// it runs first (defers are LIFO), stopping the executor before we verify.
+	defer goleak.VerifyNone(t)
+	defer shutdownEventing()
 
 	// Create a new provider and trigger some events
 	eventingImpl := &ProviderEventing{
@@ -884,10 +873,12 @@ func TestNoGoroutineLeak(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Add a handler to ensure the event system is active
-	callbackInvoked := false
+	// Add a handler to ensure the event system is active. The callback may run
+	// concurrently from multiple goroutines (executeHandler dispatches each
+	// handler in its own goroutine), so guard the flag against data races.
+	var callbackInvoked atomic.Bool
 	callback := func(details EventDetails) {
-		callbackInvoked = true
+		callbackInvoked.Store(true)
 	}
 	AddHandler(ProviderReady, &callback)
 
@@ -903,7 +894,7 @@ func TestNoGoroutineLeak(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Verify the callback was invoked
-	if !callbackInvoked {
+	if !callbackInvoked.Load() {
 		t.Error("callback should have been invoked")
 	}
 
@@ -916,12 +907,15 @@ func TestNoGoroutineLeak(t *testing.T) {
 // TestNoGoroutineLeakWithShutdownWithContext verifies that ShutdownWithContext
 // also properly cleans up goroutines.
 func TestNoGoroutineLeakWithShutdownWithContext(t *testing.T) {
-	defer goleak.VerifyNone(t,
-		// Ignore provider goroutines from the new event executor
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startListeningAndShutdownOld.func1"),
-		// Ignore the new event executor's goroutine created by ShutdownWithContext() -> initSingleton()
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
-	)
+	// Start from a clean goroutine baseline and restore a working singleton
+	// afterwards (see startLeakTest).
+	startLeakTest(t)
+
+	// ShutdownWithContext reinitializes the global event executor via
+	// initSingleton; shutdownEventing (registered after VerifyNone, so it runs
+	// first) stops that replacement before goleak verifies.
+	defer goleak.VerifyNone(t)
+	defer shutdownEventing()
 
 	eventingImpl := &ProviderEventing{c: make(chan Event, 1)}
 	err := SetProvider(struct {
@@ -933,10 +927,10 @@ func TestNoGoroutineLeakWithShutdownWithContext(t *testing.T) {
 	}
 
 	// Use ShutdownWithContext instead of Shutdown
-	err = ShutdownWithContext(context.Background())
+	err = ShutdownWithContext(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// goleak will verify no goroutines are leaked (except the new event executor)
+	// goleak will verify no goroutines are leaked
 }


### PR DESCRIPTION
## This PR
- Fixes the internal tests leaking goroutines as well as adds regression testing to ensure that this won't reoccur. 


Targeting the goroutine leak branch and then will rebase that branch