### PR TITLE
fix: prevent goroutine leaks in event executor and improve shutdown handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cucumber/godog v0.15.1
 	github.com/go-logr/logr v1.4.3
 	github.com/stretchr/testify v1.11.1
+	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -1302,7 +1302,7 @@ func TestRequirement_1_7_5(t *testing.T) {
 // is in NOT_READY.
 func TestRequirement_1_7_6(t *testing.T) {
 	t.Cleanup(func() {
-		eventing.(*eventExecutor).shutdown()
+		eventing.shutdown()
 		initSingleton()
 	})
 

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -41,7 +41,7 @@ func hydratedMocksForClientTests(t *testing.T, expectedEvaluations int) clientMo
 // and appends them to the collection of any previously added hooks.
 // When new hooks are added, previously added hooks are not removed.
 func TestRequirement_1_2_1(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockHook := NewMockHook(ctrl)
@@ -59,7 +59,7 @@ func TestRequirement_1_2_1(t *testing.T) {
 // containing an immutable `domain` field or accessor of type string,
 // which corresponds to the `domain` value supplied during client creation.
 func TestRequirement_1_2_2(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	clientName := "test-client"
 
 	client := NewClient(clientName)
@@ -85,7 +85,7 @@ func TestRequirement_1_2_2(t *testing.T) {
 // If the value returned by the underlying provider implementation does not match the expected type,
 // it's to be considered abnormal execution, and the supplied `default value` should be returned.
 func TestRequirements_1_3(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	client := NewClient("test-client")
 
 	type requirements interface {
@@ -106,7 +106,7 @@ func TestRequirements_1_3(t *testing.T) {
 // `default value` (boolean | number | string | structure, required), `evaluation context` (optional),
 // and `evaluation options` (optional), which returns an `evaluation details` structure.
 func TestRequirement_1_4_1(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	client := NewClient("test-client")
 
 	type requirements interface {
@@ -157,7 +157,7 @@ var objectValue = map[string]any{"foo": 1, "bar": true, "baz": "buz"}
 // contain the value of the `reason` field in the `flag resolution` structure returned
 // by the configured `provider`, if the field is set.
 func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	flagKey := "foo"
 
@@ -296,7 +296,7 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 // The `evaluation details` structure's `flag key` field MUST contain the `flag key`
 // argument passed to the detailed flag evaluation method.
 func TestRequirement_1_4_4(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	flagKey := "foo"
 	t.Run("BooleanValueDetails", func(t *testing.T) {
 		mocks := hydratedMocksForClientTests(t, 1)
@@ -417,7 +417,7 @@ func TestRequirement_1_4_4(t *testing.T) {
 // In cases of abnormal execution, the `evaluation details` structure's
 // `error code` field MUST contain an `error code`.
 func TestRequirement_1_4_7(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	mocks := hydratedMocksForClientTests(t, 1)
 	client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 
@@ -445,7 +445,7 @@ func TestRequirement_1_4_7(t *testing.T) {
 // In cases of abnormal execution (network failure, unhandled error, etc) the `reason` field
 // in the `evaluation details` SHOULD indicate an error.
 func TestRequirement_1_4_8(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	mocks := hydratedMocksForClientTests(t, 1)
 	client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 	mocks.providerAPI.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -482,7 +482,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("Boolean", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -516,7 +516,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	})
 
 	t.Run("String", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -550,7 +550,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	})
 
 	t.Run("Float", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 
@@ -583,7 +583,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	})
 
 	t.Run("Int", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 		var defaultValue int64 = 3
@@ -615,7 +615,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 	})
 
 	t.Run("Object", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 		mocks := hydratedMocksForClientTests(t, 2)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
 		type obj struct {
@@ -659,7 +659,7 @@ func TestRequirement_1_4_9(t *testing.T) {
 // In cases of abnormal execution, the `evaluation details` structure's `error message` field MAY contain a
 // string containing additional details about the nature of the error.
 func TestRequirement_1_4_12(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	errMessage := "error forced by test"
 
@@ -697,7 +697,7 @@ func TestRequirement_1_4_13(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("No Metadata", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mocks := hydratedMocksForClientTests(t, 1)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -723,7 +723,7 @@ func TestRequirement_1_4_13(t *testing.T) {
 	})
 
 	t.Run("Metadata present", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mocks := hydratedMocksForClientTests(t, 1)
 		client := newClient("test-client", mocks.evaluationAPI, mocks.clientHandlerAPI)
@@ -978,7 +978,7 @@ func TestFlattenContext(t *testing.T) {
 // TestBeforeHookNilContext asserts that when a Before hook returns a nil EvaluationContext it doesn't overwrite the
 // existing EvaluationContext
 func TestBeforeHookNilContext(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	hookNilContext := UnimplementedHook{}
 
@@ -998,7 +998,7 @@ func TestBeforeHookNilContext(t *testing.T) {
 }
 
 func TestErrorCodeFromProviderReturnedInEvaluationDetails(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	generalErrorCode := GeneralCode
 
@@ -1028,7 +1028,7 @@ func TestErrorCodeFromProviderReturnedInEvaluationDetails(t *testing.T) {
 }
 
 func TestObjectEvaluationShouldSupportNilValue(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	variant := "variant1"
 	reason := TargetingMatchReason
@@ -1199,7 +1199,7 @@ func TestRequirement_1_7_1(t *testing.T) {
 // The client's provider status accessor MUST indicate READY if the initialize function of the associated provider
 // terminates normally.
 func TestRequirement_1_7_2(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	if NewClient(t.Name()).State() != NotReadyState {
 		t.Fatalf("expected client to report NOT READY state")
@@ -1227,7 +1227,7 @@ func TestRequirement_1_7_2(t *testing.T) {
 // The client's provider status accessor MUST indicate ERROR if the initialize function of the associated provider
 // terminates abnormally
 func TestRequirement_1_7_3(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	provider := struct {
 		FeatureProvider
 		StateHandler
@@ -1251,7 +1251,7 @@ func TestRequirement_1_7_3(t *testing.T) {
 // The client's provider status accessor MUST indicate FATAL if the initialize function of the associated provider
 // terminates abnormally and indicates error code PROVIDER_FATAL.
 func TestRequirement_1_7_4(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	provider := struct {
 		FeatureProvider
 		StateHandler
@@ -1276,7 +1276,7 @@ func TestRequirement_1_7_4(t *testing.T) {
 // The client's provider status accessor MUST indicate FATAL if the initialize function of the associated provider
 // terminates abnormally and indicates error code PROVIDER_FATAL.
 func TestRequirement_1_7_5(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	provider := struct {
 		FeatureProvider
 		StateHandler
@@ -1303,7 +1303,7 @@ func TestRequirement_1_7_5(t *testing.T) {
 func TestRequirement_1_7_6(t *testing.T) {
 	t.Cleanup(func() {
 		eventing.shutdown()
-		initSingleton()
+		resetSingleton()
 	})
 
 	ctrl := gomock.NewController(t)
@@ -1355,7 +1355,7 @@ func TestRequirement_1_7_6(t *testing.T) {
 // The client MUST default, run error hooks, and indicate an error if flag resolution is attempted while the provider
 // is in FATAL.
 func TestRequirement_1_7_7(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	provider := struct {
 		FeatureProvider
 		StateHandler
@@ -1410,7 +1410,7 @@ func TestRequirement_5_1_5(t *testing.T) {
 
 // If the provider emits an event, the value of the client's provider status MUST be updated accordingly.
 func TestRequirement_5_3_5(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	eventually(t, func() bool {
 		return NewDefaultClient().State() == NotReadyState

--- a/openfeature/context_aware_test.go
+++ b/openfeature/context_aware_test.go
@@ -302,7 +302,7 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 		defer exec.shutdown()
 		// ShutdownWithContext below reinitializes the global event executor via
 		// initSingleton; shut that replacement down too so it doesn't leak.
-		defer func() { eventing.(*eventExecutor).shutdown() }()
+		defer func() { eventing.shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -342,7 +342,7 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 		defer exec.shutdown()
 		// ShutdownWithContext below reinitializes the global event executor via
 		// initSingleton; shut that replacement down too so it doesn't leak.
-		defer func() { eventing.(*eventExecutor).shutdown() }()
+		defer func() { eventing.shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -388,7 +388,7 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 		defer exec.shutdown()
 		// ShutdownWithContext below reinitializes the global event executor via
 		// initSingleton; shut that replacement down too so it doesn't leak.
-		defer func() { eventing.(*eventExecutor).shutdown() }()
+		defer func() { eventing.shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec

--- a/openfeature/context_aware_test.go
+++ b/openfeature/context_aware_test.go
@@ -97,6 +97,7 @@ func TestContextAwareInitialization(t *testing.T) {
 
 	// Create fresh API for isolated testing
 	exec := newEventExecutor()
+	defer exec.shutdown()
 	testAPI := newEvaluationAPI(exec)
 	api = testAPI
 	eventing = exec
@@ -235,6 +236,7 @@ func TestContextAwareShutdown(t *testing.T) {
 
 	// Create fresh API for isolated testing
 	exec := newEventExecutor()
+	defer exec.shutdown()
 	testAPI := newEvaluationAPI(exec)
 	api = testAPI
 	eventing = exec
@@ -297,6 +299,10 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	t.Run("shutdown with context affects all providers", func(t *testing.T) {
 		// Create fresh API for isolated testing
 		exec := newEventExecutor()
+		defer exec.shutdown()
+		// ShutdownWithContext below reinitializes the global event executor via
+		// initSingleton; shut that replacement down too so it doesn't leak.
+		defer func() { eventing.(*eventExecutor).shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -333,6 +339,10 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	t.Run("shutdown timeout handling", func(t *testing.T) {
 		// Create fresh API for isolated testing
 		exec := newEventExecutor()
+		defer exec.shutdown()
+		// ShutdownWithContext below reinitializes the global event executor via
+		// initSingleton; shut that replacement down too so it doesn't leak.
+		defer func() { eventing.(*eventExecutor).shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -375,6 +385,10 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	t.Run("backward compatibility with regular providers", func(t *testing.T) {
 		// Create fresh API for isolated testing
 		exec := newEventExecutor()
+		defer exec.shutdown()
+		// ShutdownWithContext below reinitializes the global event executor via
+		// initSingleton; shut that replacement down too so it doesn't leak.
+		defer func() { eventing.(*eventExecutor).shutdown() }()
 		testAPI := newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -494,6 +508,7 @@ func TestContextPropagationFixes(t *testing.T) {
 
 	// Create fresh API for isolated testing
 	exec := newEventExecutor()
+	defer exec.shutdown()
 	testAPI := newEvaluationAPI(exec)
 	api = testAPI
 	eventing = exec
@@ -542,6 +557,7 @@ func TestContextPropagationFixes(t *testing.T) {
 	t.Run("shutdown respects context cancellation", func(t *testing.T) {
 		// Reset API
 		exec = newEventExecutor()
+		defer exec.shutdown()
 		testAPI = newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -731,6 +747,7 @@ func TestEdgeCases(t *testing.T) {
 
 	// Create fresh API for isolated testing
 	exec := newEventExecutor()
+	defer exec.shutdown()
 	testAPI := newEvaluationAPI(exec)
 	api = testAPI
 	eventing = exec
@@ -738,6 +755,7 @@ func TestEdgeCases(t *testing.T) {
 	t.Run("rapid provider switching", func(t *testing.T) {
 		// Reset API
 		exec = newEventExecutor()
+		defer exec.shutdown()
 		testAPI = newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec
@@ -766,6 +784,7 @@ func TestEdgeCases(t *testing.T) {
 	t.Run("concurrent operations with different contexts", func(t *testing.T) {
 		// Reset API
 		exec = newEventExecutor()
+		defer exec.shutdown()
 		testAPI = newEvaluationAPI(exec)
 		api = testAPI
 		eventing = exec

--- a/openfeature/context_aware_test.go
+++ b/openfeature/context_aware_test.go
@@ -87,20 +87,7 @@ func (p *testContextAwareProvider) Hooks() []Hook {
 }
 
 func TestContextAwareInitialization(t *testing.T) {
-	// Save original state
-	originalAPI := api
-	originalEventing := eventing
-	defer func() {
-		api = originalAPI
-		eventing = originalEventing
-	}()
-
-	// Create fresh API for isolated testing
-	exec := newEventExecutor()
-	defer exec.shutdown()
-	testAPI := newEvaluationAPI(exec)
-	api = testAPI
-	eventing = exec
+	installIsolatedAPI(t)
 
 	t.Run("fast provider succeeds within timeout", func(t *testing.T) {
 		fastProvider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
@@ -226,20 +213,7 @@ func TestContextAwareStateHandlerDetection(t *testing.T) {
 }
 
 func TestContextAwareShutdown(t *testing.T) {
-	// Save original state
-	originalAPI := api
-	originalEventing := eventing
-	defer func() {
-		api = originalAPI
-		eventing = originalEventing
-	}()
-
-	// Create fresh API for isolated testing
-	exec := newEventExecutor()
-	defer exec.shutdown()
-	testAPI := newEvaluationAPI(exec)
-	api = testAPI
-	eventing = exec
+	installIsolatedAPI(t)
 
 	t.Run("context-aware shutdown with timeout", func(t *testing.T) {
 		provider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
@@ -288,24 +262,8 @@ func TestContextAwareShutdown(t *testing.T) {
 }
 
 func TestGlobalContextAwareShutdown(t *testing.T) {
-	// Save original state
-	originalAPI := api
-	originalEventing := eventing
-	defer func() {
-		api = originalAPI
-		eventing = originalEventing
-	}()
-
 	t.Run("shutdown with context affects all providers", func(t *testing.T) {
-		// Create fresh API for isolated testing
-		exec := newEventExecutor()
-		defer exec.shutdown()
-		// ShutdownWithContext below reinitializes the global event executor via
-		// initSingleton; shut that replacement down too so it doesn't leak.
-		defer func() { eventing.shutdown() }()
-		testAPI := newEvaluationAPI(exec)
-		api = testAPI
-		eventing = exec
+		installIsolatedAPI(t)
 
 		// Set up multiple providers
 		defaultProvider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
@@ -337,15 +295,7 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	})
 
 	t.Run("shutdown timeout handling", func(t *testing.T) {
-		// Create fresh API for isolated testing
-		exec := newEventExecutor()
-		defer exec.shutdown()
-		// ShutdownWithContext below reinitializes the global event executor via
-		// initSingleton; shut that replacement down too so it doesn't leak.
-		defer func() { eventing.shutdown() }()
-		testAPI := newEvaluationAPI(exec)
-		api = testAPI
-		eventing = exec
+		testAPI := installIsolatedAPI(t)
 
 		// Set up a provider with fast init but simulates long shutdown delay
 		slowShutdownProvider := &testContextAwareProvider{initDelay: 50 * time.Millisecond} // Fast init
@@ -383,15 +333,7 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	})
 
 	t.Run("backward compatibility with regular providers", func(t *testing.T) {
-		// Create fresh API for isolated testing
-		exec := newEventExecutor()
-		defer exec.shutdown()
-		// ShutdownWithContext below reinitializes the global event executor via
-		// initSingleton; shut that replacement down too so it doesn't leak.
-		defer func() { eventing.shutdown() }()
-		testAPI := newEvaluationAPI(exec)
-		api = testAPI
-		eventing = exec
+		installIsolatedAPI(t)
 
 		// Set up regular (non-context-aware) providers
 		defaultProvider := &NoopProvider{}
@@ -498,20 +440,7 @@ func (p *testContextAwareProviderWithShutdownDelay) Hooks() []Hook {
 }
 
 func TestContextPropagationFixes(t *testing.T) {
-	// Save original state
-	originalAPI := api
-	originalEventing := eventing
-	defer func() {
-		api = originalAPI
-		eventing = originalEventing
-	}()
-
-	// Create fresh API for isolated testing
-	exec := newEventExecutor()
-	defer exec.shutdown()
-	testAPI := newEvaluationAPI(exec)
-	api = testAPI
-	eventing = exec
+	installIsolatedAPI(t)
 
 	t.Run("shutdown uses passed context timeout", func(t *testing.T) {
 		// Create provider with fast init but slow shutdown
@@ -555,12 +484,7 @@ func TestContextPropagationFixes(t *testing.T) {
 	})
 
 	t.Run("shutdown respects context cancellation", func(t *testing.T) {
-		// Reset API
-		exec = newEventExecutor()
-		defer exec.shutdown()
-		testAPI = newEvaluationAPI(exec)
-		api = testAPI
-		eventing = exec
+		installIsolatedAPI(t)
 
 		provider := &testContextAwareProviderWithShutdownDelay{
 			initDelay:     10 * time.Millisecond,
@@ -737,28 +661,8 @@ func (p *testProviderInitError) Hooks() []Hook {
 }
 
 func TestEdgeCases(t *testing.T) {
-	// Save original state
-	originalAPI := api
-	originalEventing := eventing
-	defer func() {
-		api = originalAPI
-		eventing = originalEventing
-	}()
-
-	// Create fresh API for isolated testing
-	exec := newEventExecutor()
-	defer exec.shutdown()
-	testAPI := newEvaluationAPI(exec)
-	api = testAPI
-	eventing = exec
-
 	t.Run("rapid provider switching", func(t *testing.T) {
-		// Reset API
-		exec = newEventExecutor()
-		defer exec.shutdown()
-		testAPI = newEvaluationAPI(exec)
-		api = testAPI
-		eventing = exec
+		installIsolatedAPI(t)
 
 		providers := []*testContextAwareProvider{
 			{initDelay: 10 * time.Millisecond},
@@ -782,12 +686,7 @@ func TestEdgeCases(t *testing.T) {
 	})
 
 	t.Run("concurrent operations with different contexts", func(t *testing.T) {
-		// Reset API
-		exec = newEventExecutor()
-		defer exec.shutdown()
-		testAPI = newEvaluationAPI(exec)
-		api = testAPI
-		eventing = exec
+		installIsolatedAPI(t)
 
 		// Use channels to coordinate goroutines
 		done := make(chan error, 2)

--- a/openfeature/evaluation_context_test.go
+++ b/openfeature/evaluation_context_test.go
@@ -40,7 +40,7 @@ func TestRequirement_3_1_2(t *testing.T) {
 
 // The API, Client and invocation MUST have a method for supplying `evaluation context`.
 func TestRequirement_3_2_1(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	t.Run("API MUST have a method for supplying `evaluation context`", func(t *testing.T) {
 		SetEvaluationContext(EvaluationContext{})
@@ -85,7 +85,7 @@ func TestRequirement_3_2_1(t *testing.T) {
 // Evaluation context MUST be merged in the order: API (global) - transaction - client - invocation,
 // with duplicate values being overwritten.
 func TestRequirement_3_2_2(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	apiEvalCtx := EvaluationContext{

--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -41,11 +41,7 @@ func newEventExecutor() *eventExecutor {
 		done:                   make(chan struct{}),
 	}
 
-	// The event listener goroutine is started lazily (see startEventListener),
-	// when the first event-emitting provider is registered. This avoids leaving
-	// a background goroutine running for consumers that merely import the SDK
-	// without registering an eventing provider.
-	// See https://github.com/open-feature/go-sdk/issues/471.
+	// The event listener goroutine is started lazily (see startEventListener)
 	return &executor
 }
 
@@ -233,9 +229,7 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 			// provider produces events on eventChan (started once, lazily).
 			e.startEventListener()
 
-			e.wg.Add(1)
-			go func() {
-				defer e.wg.Done()
+			e.wg.Go(func() {
 				// event handling of the new feature provider
 				for {
 					select {
@@ -243,7 +237,6 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 						if !ok {
 							return
 						}
-						// Try to send the event, but also watch for shutdown signal
 						select {
 						case e.eventChan <- eventPayload{
 							event:   event,
@@ -256,7 +249,7 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 						return
 					}
 				}
-			}()
+			})
 		}
 	}
 
@@ -300,16 +293,10 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 	}
 }
 
-// startEventListener triggers the event listening of this executor. It is
-// invoked lazily, the first time an event-emitting provider is registered, so
-// that importing the SDK without using eventing leaves no background goroutine
-// running (see https://github.com/open-feature/go-sdk/issues/471). The sync.Once
-// guard makes repeated calls safe and ensures a single listener per executor.
+// startEventListener triggers the event listening of this executor.
 func (e *eventExecutor) startEventListener() {
 	e.once.Do(func() {
-		e.wg.Add(1)
-		go func() {
-			defer e.wg.Done()
+		e.wg.Go(func() {
 			for {
 				select {
 				case payload, ok := <-e.eventChan:
@@ -321,7 +308,7 @@ func (e *eventExecutor) startEventListener() {
 					return
 				}
 			}
-		}()
+		})
 	})
 }
 

--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -41,7 +41,11 @@ func newEventExecutor() *eventExecutor {
 		done:                   make(chan struct{}),
 	}
 
-	executor.startEventListener()
+	// The event listener goroutine is started lazily (see startEventListener),
+	// when the first event-emitting provider is registered. This avoids leaving
+	// a background goroutine running for consumers that merely import the SDK
+	// without registering an eventing provider.
+	// See https://github.com/open-feature/go-sdk/issues/471.
 	return &executor
 }
 
@@ -225,6 +229,10 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 		e.activeSubscriptions = append(e.activeSubscriptions, newProvider)
 
 		if v, ok := newProvider.featureProvider.(EventHandler); ok {
+			// Ensure the event listener is running now that an event-emitting
+			// provider produces events on eventChan (started once, lazily).
+			e.startEventListener()
+
 			e.wg.Add(1)
 			go func() {
 				defer e.wg.Done()
@@ -292,7 +300,11 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 	}
 }
 
-// startEventListener trigger the event listening of this executor
+// startEventListener triggers the event listening of this executor. It is
+// invoked lazily, the first time an event-emitting provider is registered, so
+// that importing the SDK without using eventing leaves no background goroutine
+// running (see https://github.com/open-feature/go-sdk/issues/471). The sync.Once
+// guard makes repeated calls safe and ensures a single listener per executor.
 func (e *eventExecutor) startEventListener() {
 	e.once.Do(func() {
 		e.wg.Add(1)
@@ -418,4 +430,3 @@ func (e *eventExecutor) shutdown() {
 		}
 	})
 }
-

--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -24,7 +24,10 @@ type eventExecutor struct {
 	scopedRegistry           map[string]scopedCallback
 	eventChan                chan eventPayload
 	once                     sync.Once
+	shutdownOnce             sync.Once
 	mu                       sync.Mutex
+	done                     chan struct{}
+	wg                       sync.WaitGroup
 }
 
 func newEventExecutor() *eventExecutor {
@@ -35,6 +38,7 @@ func newEventExecutor() *eventExecutor {
 		apiRegistry:            map[EventType][]EventCallback{},
 		scopedRegistry:         map[string]scopedCallback{},
 		eventChan:              make(chan eventPayload, 5),
+		done:                   make(chan struct{}),
 	}
 
 	executor.startEventListener()
@@ -221,7 +225,9 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 		e.activeSubscriptions = append(e.activeSubscriptions, newProvider)
 
 		if v, ok := newProvider.featureProvider.(EventHandler); ok {
+			e.wg.Add(1)
 			go func() {
+				defer e.wg.Done()
 				// event handling of the new feature provider
 				for {
 					select {
@@ -229,9 +235,14 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 						if !ok {
 							return
 						}
-						e.eventChan <- eventPayload{
+						// Try to send the event, but also watch for shutdown signal
+						select {
+						case e.eventChan <- eventPayload{
 							event:   event,
 							handler: newProvider.featureProvider,
+						}:
+						case <-newProvider.shutdownSemaphore:
+							return
 						}
 					case <-newProvider.shutdownSemaphore:
 						return
@@ -284,9 +295,19 @@ func (e *eventExecutor) startListeningAndShutdownOld(newProvider providerReferen
 // startEventListener trigger the event listening of this executor
 func (e *eventExecutor) startEventListener() {
 	e.once.Do(func() {
+		e.wg.Add(1)
 		go func() {
-			for payload := range e.eventChan {
-				e.triggerEvent(payload.event, payload.handler)
+			defer e.wg.Done()
+			for {
+				select {
+				case payload, ok := <-e.eventChan:
+					if !ok {
+						return
+					}
+					e.triggerEvent(payload.event, payload.handler)
+				case <-e.done:
+					return
+				}
 			}
 		}()
 	})
@@ -372,3 +393,29 @@ func isBound(provider providerReference, defaultProvider providerReference, name
 	return provider.equals(defaultProvider) ||
 		slices.ContainsFunc(namedProviders, provider.equals)
 }
+
+// shutdown stops the event executor's goroutine and waits for it to complete.
+// This should be called when the event executor is no longer needed to prevent goroutine leaks.
+func (e *eventExecutor) shutdown() {
+	e.shutdownOnce.Do(func() {
+		e.mu.Lock()
+		// Close shutdown semaphores to signal all active provider goroutines to stop
+		// Closing (rather than sending) ensures all waiting goroutines receive the signal
+		for _, sub := range e.activeSubscriptions {
+			close(sub.shutdownSemaphore)
+		}
+		e.mu.Unlock()
+
+		// Close the done channel to stop the main event listener
+		close(e.done)
+
+		// Wait for all goroutines to finish
+		e.wg.Wait()
+
+		// Drain any remaining events in the channel
+		for len(e.eventChan) > 0 {
+			<-e.eventChan
+		}
+	})
+}
+

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -51,7 +51,7 @@ func TestEventHandler_RegisterUnregisterEventProvider(t *testing.T) {
 // the associated client and API event handlers MUST run.
 func TestEventHandler_Eventing(t *testing.T) {
 	t.Run("Simple API level event", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -115,7 +115,7 @@ func TestEventHandler_Eventing(t *testing.T) {
 	})
 
 	t.Run("Simple Client level event", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -192,7 +192,7 @@ func TestEventHandler_Eventing(t *testing.T) {
 // Requirement 5.1.3 When a provider signals the occurrence of a particular event,
 // event handlers on clients which are not associated with that provider MUST NOT run.
 func TestEventHandler_clientAssociation(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	eventingImpl := &ProviderEventing{
 		c: make(chan Event, 1),
@@ -253,7 +253,7 @@ func TestEventHandler_clientAssociation(t *testing.T) {
 
 // Requirement 5.2.5 If a handler function terminates abnormally, other handler functions MUST run.
 func TestEventHandler_ErrorHandling(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	eventing := &ProviderEventing{
 		c: make(chan Event, 1),
@@ -328,7 +328,7 @@ func TestEventHandler_ErrorHandling(t *testing.T) {
 // Requirement 5.3.1 If the provider's initialize function terminates normally, PROVIDER_READY handlers MUST run.
 func TestEventHandler_InitOfProvider(t *testing.T) {
 	t.Run("for default provider in global handler scope", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -363,7 +363,7 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 	})
 
 	t.Run("for default provider with unassociated client handler", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -399,7 +399,7 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 	})
 
 	t.Run("for named provider in client scope", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -436,7 +436,7 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 	})
 
 	t.Run("no callback for named provider with no associations", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -478,7 +478,7 @@ func TestEventHandler_InitOfProvider(t *testing.T) {
 // Requirement 5.3.2 If the provider's initialize function terminates abnormally, PROVIDER_ERROR handlers MUST run.
 func TestEventHandler_InitOfProviderError(t *testing.T) {
 	t.Run("for default provider in global scope", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		initFailingProvider := struct {
 			FeatureProvider
@@ -512,7 +512,7 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 	})
 
 	t.Run("for default provider with unassociated client handler", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		initFailingProvider := struct {
 			FeatureProvider
@@ -548,7 +548,7 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 	})
 
 	t.Run("for named provider in client scope", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		initFailingProvider := struct {
 			FeatureProvider
@@ -584,7 +584,7 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 	})
 
 	t.Run("no callback for named provider with no associations", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -626,7 +626,7 @@ func TestEventHandler_InitOfProviderError(t *testing.T) {
 // Requirement 5.3.3 PROVIDER_READY handlers attached after the provider is already in a ready state MUST run immediately.
 func TestEventHandler_ProviderReadiness(t *testing.T) {
 	t.Run("for api level under default provider", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event),
@@ -661,7 +661,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 	})
 
 	t.Run("for domain associated handler", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event),
@@ -698,7 +698,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 	})
 
 	t.Run("for unassociated handler from default", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event),
@@ -734,7 +734,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 	})
 
 	t.Run("no event if provider is not ready", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		notReadyEventingProvider := struct {
 			FeatureProvider
@@ -772,7 +772,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 	})
 
 	t.Run("no event if subscribed for some other event", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		readyEventingProvider := struct {
 			FeatureProvider
@@ -814,7 +814,7 @@ func TestEventHandler_ProviderReadiness(t *testing.T) {
 // provider is already in the associated state, MUST run immediately
 func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	t.Run("ready handler runs when provider ready", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -848,7 +848,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("error handler runs when provider error", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -889,7 +889,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("stale handler runs when provider stale", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -930,7 +930,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("non-ready handler does not run when provider ready", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -966,7 +966,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("non-error handler does not run when provider error", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -1011,7 +1011,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 	})
 
 	t.Run("non-stale handler does not run when provider stale", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		eventingImpl := &ProviderEventing{
 			c: make(chan Event, 1),
@@ -1059,7 +1059,7 @@ func TestEventHandler_HandlersRunImmediately(t *testing.T) {
 // non-spec bound validations
 
 func TestEventHandler_multiSubs(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	eventingImpl := &ProviderEventing{
 		c: make(chan Event, 1),

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 )
 
@@ -1149,31 +1150,49 @@ func TestEventHandler_multiSubs(t *testing.T) {
 
 	// make sure events are received and count them
 	globalEvents := make(chan string, 10)
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		close(done)
+	})
+
 	go func() {
-		for rsp := range rspGlobal {
-			globalEvents <- rsp.ProviderName
+		for {
+			select {
+			case rsp := <-rspGlobal:
+				globalEvents <- rsp.ProviderName
+			case <-done:
+				return
+			}
 		}
 	}()
 
 	clientAEvents := make(chan string, 10)
 	go func() {
-		for rsp := range rspClientA {
-			if rsp.ProviderName != "providerOther" {
-				t.Errorf("incorrect event provider association, expected %s, got %s", "providerOther", rsp.ProviderName)
+		for {
+			select {
+			case rsp := <-rspClientA:
+				if rsp.ProviderName != "providerOther" {
+					t.Errorf("incorrect event provider association, expected %s, got %s", "providerOther", rsp.ProviderName)
+				}
+				clientAEvents <- rsp.ProviderName
+			case <-done:
+				return
 			}
-
-			clientAEvents <- rsp.ProviderName
 		}
 	}()
 
 	clientBEvents := make(chan string, 10)
 	go func() {
-		for rsp := range rspClientB {
-			if rsp.ProviderName != "providerOther" {
-				t.Errorf("incorrect event provider association, expected %s, got %s", "providerOther", rsp.ProviderName)
+		for {
+			select {
+			case rsp := <-rspClientB:
+				if rsp.ProviderName != "providerOther" {
+					t.Errorf("incorrect event provider association, expected %s, got %s", "providerOther", rsp.ProviderName)
+				}
+				clientBEvents <- rsp.ProviderName
+			case <-done:
+				return
 			}
-
-			clientBEvents <- rsp.ProviderName
 		}
 	}()
 
@@ -1541,6 +1560,7 @@ func TestEventHandler_ChannelClosure(t *testing.T) {
 	callBack := func(e EventDetails) {
 		eventCount.Add(1)
 	}
+
 	executor.AddHandler(ProviderReady, &callBack)
 	// watch for empty events
 	executor.AddHandler("", &callBack)
@@ -1656,4 +1676,92 @@ func TestEventHandler_StateUpdatedBeforeHandlersRun(t *testing.T) {
 			t.Fatal("ready handler did not run")
 		}
 	})
+}
+
+// TestBasicShutdown verifies that the shutdown method stops goroutines
+func TestBasicShutdown(t *testing.T) {
+	// Create a new event executor
+	exec := newEventExecutor()
+
+	// Give it a moment to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Shutdown should complete without hanging
+	done := make(chan struct{})
+	go func() {
+		exec.shutdown()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success - shutdown completed
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown() hung and did not complete within 2 seconds")
+	}
+}
+
+// TestNoGoroutineLeakWithMultipleProviders verifies that goroutine cleanup
+// works correctly even when multiple providers are registered.
+func TestNoGoroutineLeakWithMultipleProviders(t *testing.T) {
+	// Setup: shut down any existing goroutines from previous tests first
+	if eventing != nil {
+		eventing.(*eventExecutor).shutdown()
+	}
+	initSingleton()
+
+	defer goleak.VerifyNone(t,
+		// Ignore the new event executor's goroutines created by Shutdown() -> initSingleton()
+		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
+		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startListeningAndShutdownOld.func1"),
+	)
+
+	// Ensure we clean up the event executor at the end, including any reinitialized instance
+	defer func() {
+		if eventing != nil {
+			eventing.(*eventExecutor).shutdown()
+		}
+	}()
+
+	// Set default provider
+	defaultProvider := &ProviderEventing{c: make(chan Event, 1)}
+	err := SetProvider(struct {
+		FeatureProvider
+		EventHandler
+	}{NoopProvider{}, defaultProvider})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set named provider
+	namedProvider := &ProviderEventing{c: make(chan Event, 1)}
+	err = SetNamedProvider("test-domain", struct {
+		FeatureProvider
+		EventHandler
+	}{NoopProvider{}, namedProvider})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger events
+	defaultProvider.Invoke(Event{
+		EventType: ProviderReady,
+		ProviderEventDetails: ProviderEventDetails{
+			Message: "Default ready",
+		},
+	})
+
+	namedProvider.Invoke(Event{
+		EventType: ProviderReady,
+		ProviderEventDetails: ProviderEventDetails{
+			Message: "Named ready",
+		},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Shutdown cleans up all goroutines and reinitializes
+	Shutdown()
+
+	// goleak will verify no goroutines are leaked (except the new event executor)
 }

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 )
 
@@ -1710,59 +1709,4 @@ func TestBasicShutdown(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("shutdown() hung and did not complete within 2 seconds")
 	}
-}
-
-// TestNoGoroutineLeakWithMultipleProviders verifies that goroutine cleanup
-// works correctly even when multiple providers are registered.
-func TestNoGoroutineLeakWithMultipleProviders(t *testing.T) {
-	// Start from a clean goroutine baseline and restore a working singleton
-	// afterwards (see startLeakTest).
-	startLeakTest(t)
-
-	// Verify no goroutines leak. The shutdown below is registered after this so
-	// it runs first (defers are LIFO), stopping the executor before we verify.
-	defer goleak.VerifyNone(t)
-	defer shutdownEventing()
-
-	// Set default provider
-	defaultProvider := &ProviderEventing{c: make(chan Event, 1)}
-	err := SetProvider(struct {
-		FeatureProvider
-		EventHandler
-	}{NoopProvider{}, defaultProvider})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Set named provider
-	namedProvider := &ProviderEventing{c: make(chan Event, 1)}
-	err = SetNamedProvider("test-domain", struct {
-		FeatureProvider
-		EventHandler
-	}{NoopProvider{}, namedProvider})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Trigger events
-	defaultProvider.Invoke(Event{
-		EventType: ProviderReady,
-		ProviderEventDetails: ProviderEventDetails{
-			Message: "Default ready",
-		},
-	})
-
-	namedProvider.Invoke(Event{
-		EventType: ProviderReady,
-		ProviderEventDetails: ProviderEventDetails{
-			Message: "Named ready",
-		},
-	})
-
-	time.Sleep(100 * time.Millisecond)
-
-	// Shutdown cleans up all goroutines and reinitializes
-	Shutdown()
-
-	// goleak will verify no goroutines are leaked
 }

--- a/openfeature/event_executor_test.go
+++ b/openfeature/event_executor_test.go
@@ -32,6 +32,7 @@ func TestEventHandler_RegisterUnregisterEventProvider(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 		executor.registerDefaultProvider(eventingProvider)
 
 		if executor.defaultProviderReference.featureProvider != eventingProvider {
@@ -1223,6 +1224,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		executor.registerDefaultProvider(eventingProvider)
 
@@ -1252,6 +1254,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		executor.registerDefaultProvider(eventingProvider)
 
@@ -1286,6 +1289,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		executor.registerNamedEventingProvider("clientA", eventingProvider)
 
@@ -1320,6 +1324,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 		}
 
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		executor.registerNamedEventingProvider("clientA", eventingProvider)
 
@@ -1346,6 +1351,7 @@ func TestEventHandler_1ToNMapping(t *testing.T) {
 func TestEventHandler_Registration(t *testing.T) {
 	t.Run("API handlers", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// Add multiple - ProviderReady
 		executor.AddHandler(ProviderReady, &h1)
@@ -1384,6 +1390,7 @@ func TestEventHandler_Registration(t *testing.T) {
 
 	t.Run("Client handlers", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// Add multiple - client a
 		executor.AddClientHandler("a", ProviderReady, &h1)
@@ -1421,6 +1428,7 @@ func TestEventHandler_Registration(t *testing.T) {
 func TestEventHandler_APIRemoval(t *testing.T) {
 	t.Run("API level removal", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// Add multiple - ProviderReady
 		executor.AddHandler(ProviderReady, &h1)
@@ -1474,6 +1482,7 @@ func TestEventHandler_APIRemoval(t *testing.T) {
 
 	t.Run("Client level removal", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// Add multiple - client a
 		executor.AddClientHandler("a", ProviderReady, &h1)
@@ -1531,6 +1540,7 @@ func TestEventHandler_APIRemoval(t *testing.T) {
 
 	t.Run("remove handlers that were not added", func(t *testing.T) {
 		executor := newEventExecutor()
+		defer executor.shutdown()
 
 		// removal of non-added handlers shall not panic
 		executor.RemoveHandler(ProviderReady, &h1)
@@ -1552,6 +1562,7 @@ func TestEventHandler_ChannelClosure(t *testing.T) {
 	}
 
 	executor := newEventExecutor()
+	defer executor.shutdown()
 
 	executor.registerDefaultProvider(eventingProvider)
 	require.Len(t, executor.activeSubscriptions, 1)
@@ -1704,24 +1715,14 @@ func TestBasicShutdown(t *testing.T) {
 // TestNoGoroutineLeakWithMultipleProviders verifies that goroutine cleanup
 // works correctly even when multiple providers are registered.
 func TestNoGoroutineLeakWithMultipleProviders(t *testing.T) {
-	// Setup: shut down any existing goroutines from previous tests first
-	if eventing != nil {
-		eventing.(*eventExecutor).shutdown()
-	}
-	initSingleton()
+	// Start from a clean goroutine baseline and restore a working singleton
+	// afterwards (see startLeakTest).
+	startLeakTest(t)
 
-	defer goleak.VerifyNone(t,
-		// Ignore the new event executor's goroutines created by Shutdown() -> initSingleton()
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startListeningAndShutdownOld.func1"),
-	)
-
-	// Ensure we clean up the event executor at the end, including any reinitialized instance
-	defer func() {
-		if eventing != nil {
-			eventing.(*eventExecutor).shutdown()
-		}
-	}()
+	// Verify no goroutines leak. The shutdown below is registered after this so
+	// it runs first (defers are LIFO), stopping the executor before we verify.
+	defer goleak.VerifyNone(t)
+	defer shutdownEventing()
 
 	// Set default provider
 	defaultProvider := &ProviderEventing{c: make(chan Event, 1)}
@@ -1763,5 +1764,5 @@ func TestNoGoroutineLeakWithMultipleProviders(t *testing.T) {
 	// Shutdown cleans up all goroutines and reinitializes
 	Shutdown()
 
-	// goleak will verify no goroutines are leaked (except the new event executor)
+	// goleak will verify no goroutines are leaked
 }

--- a/openfeature/hooks_test.go
+++ b/openfeature/hooks_test.go
@@ -147,7 +147,7 @@ func TestRequirement_4_2_2_3(t *testing.T) {
 // The `before` stage MUST run before flag resolution occurs. It accepts a `hook context` (required) and
 // `hook hints` (optional) as parameters and returns either an `evaluation context` or nothing.
 func TestRequirement_4_3_2(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	t.Run("before stage MUST run before flag resolution occurs", func(t *testing.T) {
@@ -195,7 +195,7 @@ func TestRequirement_4_3_2(t *testing.T) {
 
 // Any `evaluation context` returned from a `before` hook MUST be passed to subsequent `before` hooks (via `HookContext`).
 func TestRequirement_4_3_3(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockProvider := NewMockFeatureProvider(ctrl)
@@ -255,7 +255,7 @@ func TestRequirement_4_3_3(t *testing.T) {
 // `evaluation context` in the following order:
 // before-hook (highest precedence), invocation, client, api (lowest precedence).
 func TestRequirement_4_3_4(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockProvider := NewMockFeatureProvider(ctrl)
@@ -332,7 +332,7 @@ func TestRequirement_4_3_5(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	t.Run("after hook MUST run after flag resolution occurs", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -388,7 +388,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("error hook MUST run when errors are encountered in the before stage", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -413,7 +413,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 	})
 
 	t.Run("error hook MUST run when errors are encountered during flag evaluation", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -446,7 +446,7 @@ func TestRequirement_4_3_6(t *testing.T) {
 	})
 
 	t.Run("error hook MUST run when errors are encountered during flag evaluation", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -497,7 +497,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("finally hook MUST run after the before & after stages", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -523,7 +523,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 	})
 
 	t.Run("finally hook MUST run after the error stage", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
@@ -563,7 +563,7 @@ func TestRequirement_4_3_7(t *testing.T) {
 
 // The API, Client, Provider and invocation MUST have a method for registering hooks
 func TestRequirement_4_4_1(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	t.Run("API MUST have a method for registering hooks", func(t *testing.T) {
@@ -635,7 +635,7 @@ func TestRequirement_4_4_2(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("before, after & finally hooks MUST be evaluated in the following order", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mockAPIHook := NewMockHook(ctrl)
 		AddHooks(mockAPIHook)
@@ -684,7 +684,7 @@ func TestRequirement_4_4_2(t *testing.T) {
 	})
 
 	t.Run("error hooks MUST be evaluated in the following order", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		mockAPIHook := NewMockHook(ctrl)
 		AddHooks(mockAPIHook)
@@ -756,7 +756,7 @@ func TestRequirement_4_4_6(t *testing.T) {
 	t.Run(
 		"if an error occurs during the evaluation of before hooks, any remaining before hooks MUST NOT be invoked",
 		func(t *testing.T) {
-			t.Cleanup(initSingleton)
+			t.Cleanup(resetSingleton)
 
 			mockHook1 := NewMockHook(ctrl)
 			mockHook2 := NewMockHook(ctrl)
@@ -790,7 +790,7 @@ func TestRequirement_4_4_6(t *testing.T) {
 	t.Run(
 		"if an error occurs during the evaluation of after hooks, any remaining after hooks MUST NOT be invoked",
 		func(t *testing.T) {
-			t.Cleanup(initSingleton)
+			t.Cleanup(resetSingleton)
 
 			mockHook1 := NewMockHook(ctrl)
 			mockHook2 := NewMockHook(ctrl)
@@ -827,7 +827,7 @@ func TestRequirement_4_4_6(t *testing.T) {
 
 // If an error occurs in the `before` hooks, the default value MUST be returned.
 func TestRequirement_4_4_7(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	flagKey := "foo"
@@ -879,7 +879,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 	flatCtx := flattenContext(evalCtx)
 
 	t.Run("hook hints must be passed to before, after & finally hooks", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 		mockHook := NewMockHook(ctrl)
 		mockProvider := NewMockFeatureProvider(ctrl)
 		mockProvider.EXPECT().Metadata().AnyTimes()
@@ -908,7 +908,7 @@ func TestRequirement_4_5_2(t *testing.T) {
 	})
 
 	t.Run("hook hints must be passed to error hooks", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 		mockHook := NewMockHook(ctrl)
 
 		mockProvider := NewMockFeatureProvider(ctrl)

--- a/openfeature/interfaces.go
+++ b/openfeature/interfaces.go
@@ -81,7 +81,7 @@ type eventingImpl interface {
 	IEventing
 	GetAPIRegistry() map[EventType][]EventCallback
 	GetClientRegistry(client string) scopedCallback
-
+	shutdown()
 	clientEvent
 }
 

--- a/openfeature/interfaces_mock.go
+++ b/openfeature/interfaces_mock.go
@@ -1132,6 +1132,18 @@ func (mr *MockeventingImplMockRecorder) State(domain any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockeventingImpl)(nil).State), domain)
 }
 
+// shutdown mocks base method.
+func (m *MockeventingImpl) shutdown() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "shutdown")
+}
+
+// shutdown indicates an expected call of shutdown.
+func (mr *MockeventingImplMockRecorder) shutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "shutdown", reflect.TypeOf((*MockeventingImpl)(nil).shutdown))
+}
+
 // MockclientEvent is a mock of clientEvent interface.
 type MockclientEvent struct {
 	ctrl     *gomock.Controller

--- a/openfeature/main_test.go
+++ b/openfeature/main_test.go
@@ -1,0 +1,19 @@
+package openfeature
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain provides setup and teardown for the entire test suite
+func TestMain(m *testing.M) {
+	// Run tests
+	code := m.Run()
+
+	// Final cleanup: shut down the global event executor
+	if eventing != nil {
+		eventing.(*eventExecutor).shutdown()
+	}
+
+	os.Exit(code)
+}

--- a/openfeature/main_test.go
+++ b/openfeature/main_test.go
@@ -1,19 +1,61 @@
 package openfeature
 
 import (
+	"fmt"
 	"os"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
-// TestMain provides setup and teardown for the entire test suite
+// TestMain provides setup and teardown for the entire test suite. After the
+// tests run it shuts down the global event executor and then verifies that no
+// goroutines were leaked, guarding against regressions of the leak described in
+// https://github.com/open-feature/go-sdk/issues/471.
 func TestMain(m *testing.M) {
-	// Run tests
 	code := m.Run()
 
-	// Final cleanup: shut down the global event executor
-	if eventing != nil {
-		eventing.(*eventExecutor).shutdown()
+	if code == 0 {
+		// Shut down the global event executor so its background goroutine is
+		// stopped before we verify that nothing was leaked.
+		if eventing != nil {
+			eventing.(*eventExecutor).shutdown()
+		}
+
+		if err := goleak.Find(); err != nil {
+			fmt.Fprintf(os.Stderr, "goroutine leak detected: %v\n", err)
+			code = 1
+		}
 	}
 
 	os.Exit(code)
+}
+
+// startLeakTest prepares the global event executor for a goroutine-leak test.
+//
+// It shuts down the current executor and reinitializes a fresh one so the test
+// starts from a known-clean goroutine baseline regardless of what previous
+// tests left behind. It also registers a t.Cleanup that reinitializes the
+// singleton once more, restoring a working executor for subsequent tests after
+// the test's deferred goleak verification has run (deferred calls execute
+// before t.Cleanup callbacks).
+//
+// Leak tests should pair this with a deferred shutdown of the global executor
+// (registered after the goleak verification so it runs first), e.g.:
+//
+//	startLeakTest(t)
+//	defer goleak.VerifyNone(t)
+//	defer shutdownEventing()
+func startLeakTest(t *testing.T) {
+	t.Helper()
+	shutdownEventing()
+	initSingleton()
+	t.Cleanup(initSingleton)
+}
+
+// shutdownEventing shuts down the global event executor if one is set.
+func shutdownEventing() {
+	if eventing != nil {
+		eventing.(*eventExecutor).shutdown()
+	}
 }

--- a/openfeature/main_test.go
+++ b/openfeature/main_test.go
@@ -34,8 +34,8 @@ func TestMain(m *testing.M) {
 func startLeakTest(t *testing.T) {
 	t.Helper()
 	shutdownEventing()
-	initSingleton()
-	t.Cleanup(initSingleton)
+	resetSingleton()
+	t.Cleanup(resetSingleton)
 }
 
 // shutdownEventing shuts down the global event executor if one is set.
@@ -43,4 +43,34 @@ func shutdownEventing() {
 	if eventing != nil {
 		eventing.shutdown()
 	}
+}
+
+// installIsolatedAPI replaces the global evaluation API and event executor with
+// fresh, isolated instances for the duration of the test (or subtest) and
+// returns the new API for further configuration. The previous globals are
+// restored and the executor is shut down via t.Cleanup.
+func installIsolatedAPI(t *testing.T) *evaluationAPI {
+	t.Helper()
+
+	originalAPI := api
+	originalEventing := eventing
+
+	exec := newEventExecutor()
+	testAPI := newEvaluationAPI(exec)
+	api = testAPI
+	eventing = exec
+
+	t.Cleanup(func() {
+		exec.shutdown()
+		// ShutdownWithContext (and similar) can reinitialize the global event
+		// executor via resetSingleton; shut that replacement down too so it
+		// doesn't leak.
+		if eventing != nil && eventing != exec {
+			eventing.shutdown()
+		}
+		api = originalAPI
+		eventing = originalEventing
+	})
+
+	return testAPI
 }

--- a/openfeature/main_test.go
+++ b/openfeature/main_test.go
@@ -18,7 +18,7 @@ func TestMain(m *testing.M) {
 		// Shut down the global event executor so its background goroutine is
 		// stopped before we verify that nothing was leaked.
 		if eventing != nil {
-			eventing.(*eventExecutor).shutdown()
+			eventing.shutdown()
 		}
 
 		if err := goleak.Find(); err != nil {
@@ -41,6 +41,6 @@ func startLeakTest(t *testing.T) {
 // shutdownEventing shuts down the global event executor if one is set.
 func shutdownEventing() {
 	if eventing != nil {
-		eventing.(*eventExecutor).shutdown()
+		eventing.shutdown()
 	}
 }

--- a/openfeature/main_test.go
+++ b/openfeature/main_test.go
@@ -10,8 +10,7 @@ import (
 
 // TestMain provides setup and teardown for the entire test suite. After the
 // tests run it shuts down the global event executor and then verifies that no
-// goroutines were leaked, guarding against regressions of the leak described in
-// https://github.com/open-feature/go-sdk/issues/471.
+// goroutines were leaked.
 func TestMain(m *testing.M) {
 	code := m.Run()
 
@@ -32,20 +31,6 @@ func TestMain(m *testing.M) {
 }
 
 // startLeakTest prepares the global event executor for a goroutine-leak test.
-//
-// It shuts down the current executor and reinitializes a fresh one so the test
-// starts from a known-clean goroutine baseline regardless of what previous
-// tests left behind. It also registers a t.Cleanup that reinitializes the
-// singleton once more, restoring a working executor for subsequent tests after
-// the test's deferred goleak verification has run (deferred calls execute
-// before t.Cleanup callbacks).
-//
-// Leak tests should pair this with a deferred shutdown of the global executor
-// (registered after the goleak verification so it runs first), e.g.:
-//
-//	startLeakTest(t)
-//	defer goleak.VerifyNone(t)
-//	defer shutdownEventing()
 func startLeakTest(t *testing.T) {
 	t.Helper()
 	shutdownEventing()

--- a/openfeature/openfeature.go
+++ b/openfeature/openfeature.go
@@ -18,6 +18,11 @@ func init() {
 }
 
 func initSingleton() {
+	// Shutdown existing event executor to prevent goroutine leaks
+	if eventing != nil {
+		eventing.(*eventExecutor).shutdown()
+	}
+
 	exec := newEventExecutor()
 	eventing = exec
 
@@ -149,6 +154,7 @@ func RemoveHandler(eventType EventType, callback EventCallback) {
 // hooks, event handlers, and providers.
 func Shutdown() {
 	api.Shutdown()
+	eventing.(*eventExecutor).shutdown()
 	initSingleton()
 }
 
@@ -159,6 +165,7 @@ func Shutdown() {
 // Returns an error if any provider shutdown fails or if context is cancelled during shutdown.
 func ShutdownWithContext(ctx context.Context) error {
 	err := api.ShutdownWithContext(ctx)
+	eventing.(*eventExecutor).shutdown()
 	initSingleton()
 	return err
 }

--- a/openfeature/openfeature.go
+++ b/openfeature/openfeature.go
@@ -20,7 +20,7 @@ func init() {
 func initSingleton() {
 	// Shutdown existing event executor to prevent goroutine leaks
 	if eventing != nil {
-		eventing.(*eventExecutor).shutdown()
+		eventing.shutdown()
 	}
 
 	exec := newEventExecutor()
@@ -154,7 +154,7 @@ func RemoveHandler(eventType EventType, callback EventCallback) {
 // hooks, event handlers, and providers.
 func Shutdown() {
 	api.Shutdown()
-	eventing.(*eventExecutor).shutdown()
+	eventing.shutdown()
 	initSingleton()
 }
 
@@ -165,7 +165,7 @@ func Shutdown() {
 // Returns an error if any provider shutdown fails or if context is cancelled during shutdown.
 func ShutdownWithContext(ctx context.Context) error {
 	err := api.ShutdownWithContext(ctx)
-	eventing.(*eventExecutor).shutdown()
+	eventing.shutdown()
 	initSingleton()
 	return err
 }

--- a/openfeature/openfeature.go
+++ b/openfeature/openfeature.go
@@ -14,10 +14,11 @@ var (
 
 // init initializes the OpenFeature evaluation API
 func init() {
-	initSingleton()
+	resetSingleton()
 }
 
-func initSingleton() {
+// resetSingleton stops (if running) the event executor and starts a new one.
+func resetSingleton() {
 	// Shutdown existing event executor to prevent goroutine leaks
 	if eventing != nil {
 		eventing.shutdown()
@@ -154,8 +155,7 @@ func RemoveHandler(eventType EventType, callback EventCallback) {
 // hooks, event handlers, and providers.
 func Shutdown() {
 	api.Shutdown()
-	eventing.shutdown()
-	initSingleton()
+	resetSingleton()
 }
 
 // ShutdownWithContext calls context-aware shutdown on all registered providers.
@@ -165,7 +165,6 @@ func Shutdown() {
 // Returns an error if any provider shutdown fails or if context is cancelled during shutdown.
 func ShutdownWithContext(ctx context.Context) error {
 	err := api.ShutdownWithContext(ctx)
-	eventing.shutdown()
-	initSingleton()
+	resetSingleton()
 	return err
 }

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -934,3 +934,58 @@ func TestNoGoroutineLeakWithShutdownWithContext(t *testing.T) {
 
 	// goleak will verify no goroutines are leaked
 }
+
+// TestNoGoroutineLeakWithMultipleProviders verifies that goroutine cleanup
+// works correctly even when multiple providers are registered.
+func TestNoGoroutineLeakWithMultipleProviders(t *testing.T) {
+	// Start from a clean goroutine baseline and restore a working singleton
+	// afterwards (see startLeakTest).
+	startLeakTest(t)
+
+	// Verify no goroutines leak. The shutdown below is registered after this so
+	// it runs first (defers are LIFO), stopping the executor before we verify.
+	defer goleak.VerifyNone(t)
+	defer shutdownEventing()
+
+	// Set default provider
+	defaultProvider := &ProviderEventing{c: make(chan Event, 1)}
+	err := SetProvider(struct {
+		FeatureProvider
+		EventHandler
+	}{NoopProvider{}, defaultProvider})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set named provider
+	namedProvider := &ProviderEventing{c: make(chan Event, 1)}
+	err = SetNamedProvider("test-domain", struct {
+		FeatureProvider
+		EventHandler
+	}{NoopProvider{}, namedProvider})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger events
+	defaultProvider.Invoke(Event{
+		EventType: ProviderReady,
+		ProviderEventDetails: ProviderEventDetails{
+			Message: "Default ready",
+		},
+	})
+
+	namedProvider.Invoke(Event{
+		EventType: ProviderReady,
+		ProviderEventDetails: ProviderEventDetails{
+			Message: "Named ready",
+		},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Shutdown cleans up all goroutines and reinitializes
+	Shutdown()
+
+	// goleak will verify no goroutines are leaked
+}

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -1,9 +1,9 @@
 package openfeature
 
 import (
-	"context"
 	"errors"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -846,25 +846,14 @@ func expectTimeout(t *testing.T, ch <-chan any, receiveMsg string) {
 // TestNoGoroutineLeak verifies that the event executor's goroutine is properly
 // cleaned up after shutdown, preventing goroutine leaks.
 func TestNoGoroutineLeak(t *testing.T) {
-	// Setup: shut down any existing goroutines from previous tests first
-	if eventing != nil {
-		eventing.(*eventExecutor).shutdown()
-	}
-	initSingleton()
+	// Start from a clean goroutine baseline and restore a working singleton
+	// afterwards (see startLeakTest).
+	startLeakTest(t)
 
-	// Setup: capture initial goroutines after cleanup
-	defer goleak.VerifyNone(t,
-		// Ignore the new event executor's goroutines created by Shutdown() -> initSingleton()
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startListeningAndShutdownOld.func1"),
-	)
-
-	// Ensure we clean up the event executor at the end, including any reinitialized instance
-	defer func() {
-		if eventing != nil {
-			eventing.(*eventExecutor).shutdown()
-		}
-	}()
+	// Verify no goroutines leak. The shutdown below is registered after this so
+	// it runs first (defers are LIFO), stopping the executor before we verify.
+	defer goleak.VerifyNone(t)
+	defer shutdownEventing()
 
 	// Create a new provider and trigger some events
 	eventingImpl := &ProviderEventing{
@@ -884,10 +873,12 @@ func TestNoGoroutineLeak(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Add a handler to ensure the event system is active
-	callbackInvoked := false
+	// Add a handler to ensure the event system is active. The callback may run
+	// concurrently from multiple goroutines (executeHandler dispatches each
+	// handler in its own goroutine), so guard the flag against data races.
+	var callbackInvoked atomic.Bool
 	callback := func(details EventDetails) {
-		callbackInvoked = true
+		callbackInvoked.Store(true)
 	}
 	AddHandler(ProviderReady, &callback)
 
@@ -903,7 +894,7 @@ func TestNoGoroutineLeak(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Verify the callback was invoked
-	if !callbackInvoked {
+	if !callbackInvoked.Load() {
 		t.Error("callback should have been invoked")
 	}
 
@@ -916,12 +907,15 @@ func TestNoGoroutineLeak(t *testing.T) {
 // TestNoGoroutineLeakWithShutdownWithContext verifies that ShutdownWithContext
 // also properly cleans up goroutines.
 func TestNoGoroutineLeakWithShutdownWithContext(t *testing.T) {
-	defer goleak.VerifyNone(t,
-		// Ignore provider goroutines from the new event executor
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startListeningAndShutdownOld.func1"),
-		// Ignore the new event executor's goroutine created by ShutdownWithContext() -> initSingleton()
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
-	)
+	// Start from a clean goroutine baseline and restore a working singleton
+	// afterwards (see startLeakTest).
+	startLeakTest(t)
+
+	// ShutdownWithContext reinitializes the global event executor via
+	// initSingleton; shutdownEventing (registered after VerifyNone, so it runs
+	// first) stops that replacement before goleak verifies.
+	defer goleak.VerifyNone(t)
+	defer shutdownEventing()
 
 	eventingImpl := &ProviderEventing{c: make(chan Event, 1)}
 	err := SetProvider(struct {
@@ -933,10 +927,10 @@ func TestNoGoroutineLeakWithShutdownWithContext(t *testing.T) {
 	}
 
 	// Use ShutdownWithContext instead of Shutdown
-	err = ShutdownWithContext(context.Background())
+	err = ShutdownWithContext(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// goleak will verify no goroutines are leaked (except the new event executor)
+	// goleak will verify no goroutines are leaked
 }

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -14,7 +14,7 @@ import (
 // The `API`, and any state it maintains SHOULD exist as a global singleton,
 // even in cases wherein multiple versions of the `API` are present at runtime.
 func TestRequirement_1_1_1(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	ctrl := gomock.NewController(t)
 	mockProvider := NewMockFeatureProvider(ctrl)
@@ -37,7 +37,7 @@ func TestRequirement_1_1_1(t *testing.T) {
 // The `API` MUST provide a function to set the default `provider`,
 // which accepts an API-conformant `provider` implementation.
 func TestRequirement_1_1_2_1(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockProvider := NewMockFeatureProvider(ctrl)
@@ -58,7 +58,7 @@ func TestRequirement_1_1_2_1(t *testing.T) {
 // to resolve flag values.
 func TestRequirement_1_1_2_2(t *testing.T) {
 	t.Run("default provider", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		provider, initSem, _ := setupProviderWithSemaphores()
 
@@ -75,7 +75,7 @@ func TestRequirement_1_1_2_2(t *testing.T) {
 	})
 
 	t.Run("named provider", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		provider, initSem, _ := setupProviderWithSemaphores()
 
@@ -98,7 +98,7 @@ func TestRequirement_1_1_2_2(t *testing.T) {
 // longer being used to resolve flag values.
 func TestRequirement_1_1_2_3(t *testing.T) {
 	t.Run("default provider", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		provider, initSem, shutdownSem := setupProviderWithSemaphores()
 
@@ -122,7 +122,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 	})
 
 	t.Run("named provider", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		provider, initSem, shutdownSem := setupProviderWithSemaphores()
 
@@ -148,7 +148,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 	})
 
 	t.Run("ignore shutdown for multiple references - default bound", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		// setup
 		provider, initSem, shutdownSem := setupProviderWithSemaphores()
@@ -184,7 +184,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 	})
 
 	t.Run("ignore shutdown for multiple references - domain client bound", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		// setup
 		providerA, initSemA, shutdownSemA := setupProviderWithSemaphores()
@@ -224,7 +224,7 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 
 // The API SHOULD provide functions to set a provider and wait for the initialize function to return or throw.
 func TestRequirement_1_1_2_4(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	t.Run("default provider", func(t *testing.T) {
 		// given - a provider with state handling capability, with substantial initializing delay
@@ -366,7 +366,7 @@ func TestRequirement_1_1_2_4(t *testing.T) {
 // The `API` MUST provide a function to bind a given `provider` to one or more client `domain`s.
 // If the client-domain already has a bound provider, it is overwritten with the new mapping.
 func TestRequirement_1_1_3(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	// Setup
 
@@ -442,7 +442,7 @@ func TestRequirement_1_1_3(t *testing.T) {
 // and appends them to the collection of any previously added hooks. When new hooks are added,
 // previously added hooks are not removed.
 func TestRequirement_1_1_4(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	ctrl := gomock.NewController(t)
 
 	mockHook := NewMockHook(ctrl)
@@ -457,7 +457,7 @@ func TestRequirement_1_1_4(t *testing.T) {
 
 // The API MUST provide a function for retrieving the metadata field of the configured `provider`.
 func TestRequirement_1_1_5(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	t.Run("default provider", func(t *testing.T) {
 		defaultProvider := NoopProvider{}
@@ -487,7 +487,7 @@ func TestRequirement_1_1_5(t *testing.T) {
 // The `API` MUST provide a function for creating a `client` which accepts the following options:
 // - domain (optional): A logical string identifier for the client.
 func TestRequirement_1_1_6(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	t.Run("client from direct invocation", func(t *testing.T) {
 		client := NewClient("test-client")
@@ -513,7 +513,7 @@ func TestRequirement_1_1_6(t *testing.T) {
 
 // The client creation function MUST NOT throw, or otherwise abnormally terminate.
 func TestRequirement_1_1_7(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	type clientCreationFunc func(name string) *Client
 
 	// asserting that our NewClient method matches this signature is enough to deduce that no error is returned
@@ -524,7 +524,7 @@ func TestRequirement_1_1_7(t *testing.T) {
 
 // The API MUST define a mechanism to propagate a shutdown request to active providers.
 func TestRequirement_1_6_1(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	provider, initSem, shutdownSem := setupProviderWithSemaphores()
 
@@ -544,7 +544,7 @@ func TestRequirement_1_6_1(t *testing.T) {
 // The API's `shutdown` function MUST reset all state of the API, removing all
 // hooks, event handlers, and providers.
 func TestRequirement_1_6_2(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	// TODO: test that hooks and event handlers are removed as well. This only
 	// tests that providers are removed.
@@ -593,7 +593,7 @@ func TestRequirement_EventCompliance(t *testing.T) {
 	// The client MUST provide a function for associating handler functions with a particular provider event type.
 	// The API and client MUST provide a function allowing the removal of event handlers.
 	t.Run("requirement_5_2_1 & requirement_5_2_1", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		clientName := "OFClient"
 
@@ -648,7 +648,7 @@ func TestRequirement_EventCompliance(t *testing.T) {
 
 	// The API MUST provide a function for associating handler functions with a particular provider event type.
 	t.Run("requirement_5_2_2 & requirement_5_2_1", func(t *testing.T) {
-		t.Cleanup(initSingleton)
+		t.Cleanup(resetSingleton)
 
 		// adding handlers
 		AddHandler(ProviderReady, &h1)
@@ -704,7 +704,7 @@ func TestRequirement_EventCompliance(t *testing.T) {
 
 // If there is no client domain bound provider, then return the default provider
 func TestDefaultClientUsage(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	ctrl := gomock.NewController(t)
 	defaultProvider := NewMockFeatureProvider(ctrl)
@@ -724,7 +724,7 @@ func TestDefaultClientUsage(t *testing.T) {
 }
 
 func TestLateBindingOfDefaultProvider(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 	// we are expecting
 	expectedResultUnboundProvider := "default-value-from-unbound-provider"
 	expectedResultFromLateDefaultProvider := "value-from-late-default-provider"
@@ -762,7 +762,7 @@ func TestLateBindingOfDefaultProvider(t *testing.T) {
 
 // Nil providers are not accepted for default and named providers
 func TestForNilProviders(t *testing.T) {
-	t.Cleanup(initSingleton)
+	t.Cleanup(resetSingleton)
 
 	err := SetProvider(nil)
 	if err == nil {
@@ -912,7 +912,7 @@ func TestNoGoroutineLeakWithShutdownWithContext(t *testing.T) {
 	startLeakTest(t)
 
 	// ShutdownWithContext reinitializes the global event executor via
-	// initSingleton; shutdownEventing (registered after VerifyNone, so it runs
+	// resetSingleton; shutdownEventing (registered after VerifyNone, so it runs
 	// first) stops that replacement before goleak verifies.
 	defer goleak.VerifyNone(t)
 	defer shutdownEventing()

--- a/openfeature/reference.go
+++ b/openfeature/reference.go
@@ -9,7 +9,7 @@ func newProviderRef(provider FeatureProvider) providerReference {
 	return providerReference{
 		featureProvider:   provider,
 		kind:              reflect.TypeOf(provider).Kind(),
-		shutdownSemaphore: make(chan any, 1),
+		shutdownSemaphore: make(chan any, 1), // Buffered to allow both send and close operations
 	}
 }
 


### PR DESCRIPTION
## This PR
- properly shuts down the event executor
- Fixes internal test goroutines leaking + consumer threads leaking too in downstream tests. (#471 )

### Related Issues
- Fixes #471 
### Notes
This is an updated version of #472 because i lack perms to push to that branch :P 

### How to test
CI/Unit testing handles this. 
