### PR TITLE
fix: guard against nil ContextEvaluator func in memprovider Resolve

### DIFF
--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -226,7 +226,9 @@ func (flag *InMemoryFlag) Resolve(defaultValue any, flatCtx openfeature.Flattene
 	}
 
 	// first resolve from context callback
-	if flag.ContextEvaluator != nil {
+	// ContextEvaluator is a pointer to a func, so guard against both a nil
+	// pointer and a non-nil pointer to a nil func before dereferencing.
+	if flag.ContextEvaluator != nil && *flag.ContextEvaluator != nil {
 		return (*flag.ContextEvaluator)(*flag, flatCtx)
 	}
 

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -246,19 +246,17 @@ func TestInMemoryProvider_NilContextEvaluatorFunc(t *testing.T) {
 
 	ctx := t.Context()
 
-	t.Run("nil evaluator func falls back to default variant without panic", func(t *testing.T) {
-		evaluation := memoryProvider.BooleanEvaluation(ctx, "nilFnFlag", false, nil)
+	evaluation := memoryProvider.BooleanEvaluation(ctx, "nilFnFlag", false, nil)
 
-		if evaluation.Value != true {
-			t.Errorf("incorrect evaluation, expected %v, got %v", true, evaluation.Value)
-		}
-		if evaluation.Variant != "true" {
-			t.Errorf("incorrect variant, expected %q, got %q", "true", evaluation.Variant)
-		}
-		if evaluation.Reason != openfeature.StaticReason {
-			t.Errorf("incorrect reason, expected %q, got %q", openfeature.StaticReason, evaluation.Reason)
-		}
-	})
+	if evaluation.Value != true {
+		t.Errorf("incorrect evaluation, expected %v, got %v", true, evaluation.Value)
+	}
+	if evaluation.Variant != "true" {
+		t.Errorf("incorrect variant, expected %q, got %q", "true", evaluation.Variant)
+	}
+	if evaluation.Reason != openfeature.StaticReason {
+		t.Errorf("incorrect reason, expected %q, got %q", openfeature.StaticReason, evaluation.Reason)
+	}
 }
 
 func TestInMemoryProvider_MissingFlag(t *testing.T) {

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -225,6 +225,42 @@ func TestInMemoryProvider_WithContext(t *testing.T) {
 	})
 }
 
+func TestInMemoryProvider_NilContextEvaluatorFunc(t *testing.T) {
+	// ContextEvaluator is a non-nil pointer to a nil func. The pointer passes a
+	// plain != nil guard, so a naive dereference would panic. The flag must fall
+	// back to the default variant instead.
+	var nilFn func(callerFlag InMemoryFlag, flatCtx openfeature.FlattenedContext) (any, openfeature.ProviderResolutionDetail)
+
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{
+		"nilFnFlag": {
+			Key:            "nilFnFlag",
+			State:          Enabled,
+			DefaultVariant: "true",
+			Variants: map[string]any{
+				"true":  true,
+				"false": false,
+			},
+			ContextEvaluator: &nilFn,
+		},
+	})
+
+	ctx := t.Context()
+
+	t.Run("nil evaluator func falls back to default variant without panic", func(t *testing.T) {
+		evaluation := memoryProvider.BooleanEvaluation(ctx, "nilFnFlag", false, nil)
+
+		if evaluation.Value != true {
+			t.Errorf("incorrect evaluation, expected %v, got %v", true, evaluation.Value)
+		}
+		if evaluation.Variant != "true" {
+			t.Errorf("incorrect variant, expected %q, got %q", "true", evaluation.Variant)
+		}
+		if evaluation.Reason != openfeature.StaticReason {
+			t.Errorf("incorrect reason, expected %q, got %q", openfeature.StaticReason, evaluation.Reason)
+		}
+	})
+}
+
 func TestInMemoryProvider_MissingFlag(t *testing.T) {
 	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{})
 


### PR DESCRIPTION
`memprovider.InMemoryFlag.ContextEvaluator` is typed `*func(...)`. `Resolve`
only checked the pointer for nil, so a non-nil pointer to a nil func passed the
guard and panicked on the dereference-and-call. This adds the missing inner
nil-func check so such a flag falls back to the default variant, plus a
regression test.

Fixes #521

Validation:
- `make test` (go test -tags testtools -race): all packages pass, memprovider at 86.9% coverage
- `make lint` (golangci-lint v2.9.0): 0 issues
- Confirmed the new test panics against the old guard and passes with the fix