### PR TITLE
fix: disallow provider registration and initialization after API shutdown

### DIFF
--- a/openfeature/isolated_api_test.go
+++ b/openfeature/isolated_api_test.go
@@ -2,6 +2,7 @@ package openfeature
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -391,4 +392,34 @@ func TestIsolatedAPI_ShutdownWithContextStopsEventExecutor(t *testing.T) {
 	if err := instance.Shutdown(t.Context()); err != nil {
 		t.Fatalf("ShutdownWithContext on isolated instance: %v", err)
 	}
+}
+
+func TestIsolatedAPI_SetProviderRejectedAfterShutdown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := NewMockFeatureProvider(ctrl)
+
+	instance := newAPI()
+	if err := instance.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	t.Run("default", func(t *testing.T) {
+		if err := instance.SetProvider(t.Context(), provider); !errors.Is(err, errAPIShutdown) {
+			t.Errorf("SetProvider: expected errAPIShutdown, got: %v", err)
+		}
+
+		if err := instance.SetProviderAndWait(t.Context(), provider); !errors.Is(err, errAPIShutdown) {
+			t.Errorf("SetProviderAndWait: expected errAPIShutdown, got: %v", err)
+		}
+	})
+
+	t.Run("domain", func(t *testing.T) {
+		if err := instance.SetProvider(t.Context(), provider, WithDomain("d")); !errors.Is(err, errAPIShutdown) {
+			t.Errorf("SetProvider with domain: expected errAPIShutdown, got: %v", err)
+		}
+
+		if err := instance.SetProviderAndWait(t.Context(), provider, WithDomain("d")); !errors.Is(err, errAPIShutdown) {
+			t.Errorf("SetProviderAndWait with domain: expected errAPIShutdown, got: %v", err)
+		}
+	})
 }

--- a/openfeature/isolated_api_test.go
+++ b/openfeature/isolated_api_test.go
@@ -414,7 +414,6 @@ func TestIsolatedAPI_ShutdownContextCancelled(t *testing.T) {
 	err = instance.Shutdown(ctx)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("wanted context.Canceled, got: %v", err)
-		t.Errorf("state after shutdown: %d", instance.state)
 	}
 
 	if instance.state != evaluationAPIStateActive {

--- a/openfeature/isolated_api_test.go
+++ b/openfeature/isolated_api_test.go
@@ -394,6 +394,47 @@ func TestIsolatedAPI_ShutdownWithContextStopsEventExecutor(t *testing.T) {
 	}
 }
 
+func TestIsolatedAPI_ShutdownContextCancelled(t *testing.T) {
+	instance := newAPI()
+
+	// Set a provider using SetProvider (async) with a slow init,
+	// so the instance has an in-flight count when Shutdown is entered.
+	provider := &testContextAwareProvider{initDelay: 100 * time.Millisecond}
+	err := instance.SetProvider(t.Context(), provider)
+	if err != nil {
+		t.Fatalf("SetProvider: %v", err)
+	}
+
+	// Shutdown with an already-cancelled context.
+	// The instance blocks until the async init finishes, then the
+	// select picks up ctx.Done() and restores the state to active.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err = instance.Shutdown(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("wanted context.Canceled, got: %v", err)
+		t.Errorf("state after shutdown: %d", instance.state)
+	}
+
+	if instance.state != evaluationAPIStateActive {
+		t.Errorf("wanted state restored to active, got: %d", instance.state)
+	}
+
+	// State was restored, so SetProvider should work again.
+	err = instance.SetProvider(t.Context(), &testContextAwareProvider{initDelay: time.Millisecond})
+	if err != nil {
+		t.Errorf("wanted SetProvider to succeed after cancelled shutdown, got: %v", err)
+	}
+
+	if err = instance.Shutdown(t.Context()); err != nil {
+		t.Errorf("cleanup shutdown: %v", err)
+	}
+	if instance.state != evaluationAPIStateShutdown {
+		t.Errorf("wanted state shutdown after cleanup, got: %d", instance.state)
+	}
+}
+
 func TestIsolatedAPI_SetProviderRejectedAfterShutdown(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	provider := NewMockFeatureProvider(ctrl)

--- a/openfeature/openfeature_api.go
+++ b/openfeature/openfeature_api.go
@@ -127,7 +127,7 @@ type EvaluationAPI struct {
 
 // newEvaluationAPI is a helper to generate an API. Used internally
 func newEvaluationAPI(eventExecutor *eventExecutor) *EvaluationAPI {
-	a := &EvaluationAPI{
+	return &EvaluationAPI{
 		defaultProvider: NoopProvider{},
 		domainProviders: map[string]FeatureProvider{},
 		hks:             []Hook{},
@@ -136,7 +136,6 @@ func newEvaluationAPI(eventExecutor *eventExecutor) *EvaluationAPI {
 		eventExecutor:   eventExecutor,
 		state:           evaluationAPIStateActive,
 	}
-	return a
 }
 
 // SetProvider sets a FeatureProvider with context-aware initialization.

--- a/openfeature/openfeature_api.go
+++ b/openfeature/openfeature_api.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"slices"
 	"sync"
-	"sync/atomic"
 )
 
 // providerBindingEntry holds a strong reference to the provider and the API instance it is bound to.
@@ -122,7 +121,7 @@ type EvaluationAPI struct {
 	evalCtx         EvaluationContext
 	eventExecutor   *eventExecutor
 	mu              sync.RWMutex
-	state           atomic.Uint32
+	state           uint32
 	initWg          sync.WaitGroup
 }
 
@@ -135,9 +134,8 @@ func newEvaluationAPI(eventExecutor *eventExecutor) *EvaluationAPI {
 		evalCtx:         EvaluationContext{},
 		mu:              sync.RWMutex{},
 		eventExecutor:   eventExecutor,
-		state:           atomic.Uint32{},
+		state:           evaluationAPIStateActive,
 	}
-	a.state.Store(evaluationAPIStateActive)
 	return a
 }
 
@@ -217,7 +215,7 @@ func (a *EvaluationAPI) setProvider(ctx context.Context, provider FeatureProvide
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if a.state.Load() == evaluationAPIStateShutdown {
+	if a.state == evaluationAPIStateShutdown {
 		return nil, errAPIShutdown
 	}
 
@@ -248,7 +246,7 @@ func (a *EvaluationAPI) setDomainProvider(ctx context.Context, domain string, pr
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	if a.state.Load() == evaluationAPIStateShutdown {
+	if a.state == evaluationAPIStateShutdown {
 		return nil, errAPIShutdown
 	}
 
@@ -279,22 +277,17 @@ func (a *EvaluationAPI) initNew(ctx context.Context, domain string, newProvider 
 	a.initWg.Add(1)
 	go func(executor *eventExecutor, evalCtx EvaluationContext, ctx context.Context, provider FeatureProvider, domain string) {
 		defer a.initWg.Done()
-		switch {
-		case a.state.Load() == evaluationAPIStateShutdown:
-			errCh <- errAPIShutdown
-		default:
-			event, err := initializerWithContext(ctx, provider, evalCtx)
-			executor.triggerEvent(event, provider)
+		event, err := initializerWithContext(ctx, provider, evalCtx)
+		executor.triggerEvent(event, provider)
 
-			if err != nil {
-				if domain == "" {
-					err = fmt.Errorf("failed to initialize default provider %q: %w", provider.Metadata().Name, err)
-				} else {
-					err = fmt.Errorf("failed to initialize named provider %q for domain %q: %w", provider.Metadata().Name, domain, err)
-				}
+		if err != nil {
+			if domain == "" {
+				err = fmt.Errorf("failed to initialize default provider %q: %w", provider.Metadata().Name, err)
+			} else {
+				err = fmt.Errorf("failed to initialize named provider %q for domain %q: %w", provider.Metadata().Name, domain, err)
 			}
-			errCh <- err
 		}
+		errCh <- err
 	}(a.eventExecutor, a.evalCtx, ctx, newProvider, domain)
 
 	return errCh
@@ -412,26 +405,26 @@ func (a *EvaluationAPI) RemoveHandler(eventType EventType, callback EventCallbac
 func (a *EvaluationAPI) Shutdown(ctx context.Context) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if !a.state.CompareAndSwap(evaluationAPIStateActive, evaluationAPIStateShutdown) {
+	if a.state == evaluationAPIStateShutdown {
 		return nil
 	}
+	a.state = evaluationAPIStateShutdown
 
-	// Wait for in-flight provider initializations to finish,
-	// but respect the caller's deadline/cancellation.
-	done := make(chan struct{})
-	go func() {
-		a.initWg.Wait()
-		close(done)
-	}()
+	// Wait for in-flight provider initializations to finish.
+	// sync.WaitGroup requires that if reused, all new Add calls happen
+	// after all previous Wait calls have returned. This ensures we can
+	// safely register new providers if shutdown is cancelled (ctx.Done).
+	a.initWg.Wait()
+
 	select {
-	case <-done:
-		// All in-flight initializations completed.
 	case <-ctx.Done():
-		// Caller cancelled or timed out. Revert state so the API
-		// remains usable and Shutdown can be retried with a longer
-		// deadline. Nothing has been torn down yet.
-		a.state.Store(evaluationAPIStateActive)
+		// Wait for in-flight initializations to finish before restoring state,
+		// preventing later provider registration from calling initWg.Add
+		// during an outstanding Wait.
+		a.state = evaluationAPIStateActive
 		return ctx.Err()
+	default:
+		// All in-flight initializations completed.
 	}
 
 	var errs []error

--- a/openfeature/openfeature_api.go
+++ b/openfeature/openfeature_api.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"sync"
+	"sync/atomic"
 )
 
 // providerBindingEntry holds a strong reference to the provider and the API instance it is bound to.
@@ -32,6 +33,12 @@ var (
 	providerBindingsMu    sync.Mutex
 	errNilProvider        = errors.New("provider cannot be set to nil")
 	errNilDefaultProvider = errors.New("default provider cannot be set to nil")
+	errAPIShutdown        = errors.New("api instance has been shut down")
+)
+
+const (
+	evaluationAPIStateActive uint32 = iota
+	evaluationAPIStateShutdown
 )
 
 // providerBindingKey returns a stable, hashable identity for provider suitable for use as a map key,
@@ -115,18 +122,23 @@ type EvaluationAPI struct {
 	evalCtx         EvaluationContext
 	eventExecutor   *eventExecutor
 	mu              sync.RWMutex
+	state           atomic.Uint32
+	initWg          sync.WaitGroup
 }
 
 // newEvaluationAPI is a helper to generate an API. Used internally
 func newEvaluationAPI(eventExecutor *eventExecutor) *EvaluationAPI {
-	return &EvaluationAPI{
+	a := &EvaluationAPI{
 		defaultProvider: NoopProvider{},
 		domainProviders: map[string]FeatureProvider{},
 		hks:             []Hook{},
 		evalCtx:         EvaluationContext{},
 		mu:              sync.RWMutex{},
 		eventExecutor:   eventExecutor,
+		state:           atomic.Uint32{},
 	}
+	a.state.Store(evaluationAPIStateActive)
+	return a
 }
 
 // SetProvider sets a FeatureProvider with context-aware initialization.
@@ -205,6 +217,10 @@ func (a *EvaluationAPI) setProvider(ctx context.Context, provider FeatureProvide
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	if a.state.Load() == evaluationAPIStateShutdown {
+		return nil, errAPIShutdown
+	}
+
 	if err := bindProvider(provider, a); err != nil {
 		return nil, err
 	}
@@ -232,6 +248,10 @@ func (a *EvaluationAPI) setDomainProvider(ctx context.Context, domain string, pr
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	if a.state.Load() == evaluationAPIStateShutdown {
+		return nil, errAPIShutdown
+	}
+
 	if err := bindProvider(provider, a); err != nil {
 		return nil, err
 	}
@@ -256,18 +276,25 @@ func (a *EvaluationAPI) initNew(ctx context.Context, domain string, newProvider 
 	errCh := make(chan error, 1)
 
 	// Initialize new provider async. The caller may wait on the channel.
+	a.initWg.Add(1)
 	go func(executor *eventExecutor, evalCtx EvaluationContext, ctx context.Context, provider FeatureProvider, domain string) {
-		event, err := initializerWithContext(ctx, provider, evalCtx)
-		executor.triggerEvent(event, provider)
+		defer a.initWg.Done()
+		switch {
+		case a.state.Load() == evaluationAPIStateShutdown:
+			errCh <- errAPIShutdown
+		default:
+			event, err := initializerWithContext(ctx, provider, evalCtx)
+			executor.triggerEvent(event, provider)
 
-		if err != nil {
-			if domain == "" {
-				err = fmt.Errorf("failed to initialize default provider %q: %w", provider.Metadata().Name, err)
-			} else {
-				err = fmt.Errorf("failed to initialize named provider %q for domain %q: %w", provider.Metadata().Name, domain, err)
+			if err != nil {
+				if domain == "" {
+					err = fmt.Errorf("failed to initialize default provider %q: %w", provider.Metadata().Name, err)
+				} else {
+					err = fmt.Errorf("failed to initialize named provider %q for domain %q: %w", provider.Metadata().Name, domain, err)
+				}
 			}
+			errCh <- err
 		}
-		errCh <- err
 	}(a.eventExecutor, a.evalCtx, ctx, newProvider, domain)
 
 	return errCh
@@ -385,6 +412,28 @@ func (a *EvaluationAPI) RemoveHandler(eventType EventType, callback EventCallbac
 func (a *EvaluationAPI) Shutdown(ctx context.Context) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if !a.state.CompareAndSwap(evaluationAPIStateActive, evaluationAPIStateShutdown) {
+		return nil
+	}
+
+	// Wait for in-flight provider initializations to finish,
+	// but respect the caller's deadline/cancellation.
+	done := make(chan struct{})
+	go func() {
+		a.initWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// All in-flight initializations completed.
+	case <-ctx.Done():
+		// Caller cancelled or timed out. Revert state so the API
+		// remains usable and Shutdown can be retried with a longer
+		// deadline. Nothing has been torn down yet.
+		a.state.Store(evaluationAPIStateActive)
+		return ctx.Err()
+	}
+
 	var errs []error
 
 	// Shutdown default provider

--- a/openfeature/openfeature_api_test.go
+++ b/openfeature/openfeature_api_test.go
@@ -3,6 +3,7 @@ package openfeature_test
 import (
 	"reflect"
 	"slices"
+	"sync/atomic"
 	"testing"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -89,4 +90,39 @@ func TestEvaluationAPIBreakingPreventer(t *testing.T) {
 	if err := api.Shutdown(ctx); err != nil {
 		t.Errorf("Shutdown: unexpected error: %v", err)
 	}
+}
+
+func TestProviderInitShutdown(t *testing.T) {
+	p := &ttprovider{t: t}
+	api := isolated.NewAPI()
+
+	if err := api.SetProvider(t.Context(), p); err != nil {
+		t.Fatalf("SetProvider: %v", err)
+	}
+	if err := api.Shutdown(t.Context()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	if !p.shutdownCalled.Load() {
+		t.Error("provider Shutdown was not called")
+	}
+}
+
+var _ openfeature.StateHandler = (*ttprovider)(nil)
+
+type ttprovider struct {
+	openfeature.NoopProvider
+	shutdownCalled atomic.Bool
+	t              testing.TB
+}
+
+func (a *ttprovider) Init(openfeature.EvaluationContext) error {
+	if a.shutdownCalled.Load() {
+		a.t.Error("unexpected init call after Shutdown")
+	}
+	return nil
+}
+
+func (a *ttprovider) Shutdown() {
+	a.shutdownCalled.Store(true)
 }


### PR DESCRIPTION
## This PR

- track evaluationAPIState (active/shutdown)
- guard SetProvider and SetDomainProvider to reject calls after shutdown
- wait for in-flight provider initializations before shutting down process

closes #495
