### PR TITLE
fix: support binding a provider to multiple domains

### DIFF
--- a/openfeature/context_aware_test.go
+++ b/openfeature/context_aware_test.go
@@ -9,88 +9,44 @@ import (
 
 // testContextAwareProvider is a test provider that implements ContextAwareStateHandler
 type testContextAwareProvider struct {
-	initDelay time.Duration
+	FeatureProvider
+	stateContextAwareHandlerForTests
 }
 
-func (p *testContextAwareProvider) Metadata() Metadata {
-	return Metadata{Name: "test-context-aware-provider"}
-}
-
-// InitWithContext implements ContextAwareStateHandler
-func (p *testContextAwareProvider) InitWithContext(ctx context.Context, evalCtx EvaluationContext) error {
-	select {
-	case <-time.After(p.initDelay):
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+func newTestContextAwareProvider(t testing.TB, initDelay time.Duration, customShutdownDelay ...time.Duration) *testContextAwareProvider {
+	t.Helper()
+	shutdownDelay := initDelay
+	if len(customShutdownDelay) == 1 {
+		shutdownDelay = customShutdownDelay[0]
 	}
-}
-
-// Init implements StateHandler for backward compatibility
-func (p *testContextAwareProvider) Init(evalCtx EvaluationContext) error {
-	return p.InitWithContext(context.Background(), evalCtx)
-}
-
-// ShutdownWithContext implements ContextAwareStateHandler
-func (p *testContextAwareProvider) ShutdownWithContext(ctx context.Context) error {
-	select {
-	case <-time.After(p.initDelay): // Reuse delay for shutdown simulation
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	return &testContextAwareProvider{
+		FeatureProvider: NoopProvider{},
+		stateContextAwareHandlerForTests: stateContextAwareHandlerForTests{
+			initF: func(ctx context.Context, _ EvaluationContext) error {
+				select {
+				case <-time.After(initDelay):
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+			shutdownF: func(ctx context.Context) error {
+				select {
+				case <-time.After(shutdownDelay):
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+		},
 	}
-}
-
-// Shutdown implements StateHandler for backward compatibility
-func (p *testContextAwareProvider) Shutdown() {
-	// For backward compatibility, use background context with no timeout
-	_ = p.ShutdownWithContext(context.Background())
-}
-
-func (p *testContextAwareProvider) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, flatCtx FlattenedContext) BoolResolutionDetail {
-	return BoolResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProvider) StringEvaluation(ctx context.Context, flag string, defaultValue string, flatCtx FlattenedContext) StringResolutionDetail {
-	return StringResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProvider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, flatCtx FlattenedContext) FloatResolutionDetail {
-	return FloatResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProvider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, flatCtx FlattenedContext) IntResolutionDetail {
-	return IntResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, flatCtx FlattenedContext) InterfaceResolutionDetail {
-	return InterfaceResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProvider) Hooks() []Hook {
-	return []Hook{}
 }
 
 func TestContextAwareInitialization(t *testing.T) {
 	installIsolatedAPI(t)
 
 	t.Run("fast provider succeeds within timeout", func(t *testing.T) {
-		fastProvider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
+		fastProvider := newTestContextAwareProvider(t, 50*time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 		defer cancel()
@@ -102,7 +58,7 @@ func TestContextAwareInitialization(t *testing.T) {
 	})
 
 	t.Run("slow provider times out", func(t *testing.T) {
-		slowProvider := &testContextAwareProvider{initDelay: 800 * time.Millisecond}
+		slowProvider := newTestContextAwareProvider(t, 800*time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 		defer cancel()
@@ -117,7 +73,7 @@ func TestContextAwareInitialization(t *testing.T) {
 	})
 
 	t.Run("async initialization returns immediately", func(t *testing.T) {
-		asyncProvider := &testContextAwareProvider{initDelay: 200 * time.Millisecond}
+		asyncProvider := newTestContextAwareProvider(t, 200*time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 		defer cancel()
@@ -140,16 +96,16 @@ func TestContextAwareInitialization(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
-		if err := SetProviderWithContext(ctx, &testContextAwareProvider{}); err != nil {
+		if err := SetProviderWithContext(ctx, newTestContextAwareProvider(t, 0)); err != nil {
 			t.Errorf("SetProviderWithContext with cancelled context: got %v, want nil", err)
 		}
-		if err := SetNamedProviderWithContext(ctx, "cancelled-domain", &testContextAwareProvider{}); err != nil {
+		if err := SetNamedProviderWithContext(ctx, "cancelled-domain", newTestContextAwareProvider(t, 0)); err != nil {
 			t.Errorf("SetNamedProviderWithContext with cancelled context: got %v, want nil", err)
 		}
 	})
 
 	t.Run("named provider with context works", func(t *testing.T) {
-		namedProvider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
+		namedProvider := newTestContextAwareProvider(t, 50*time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 		defer cancel()
@@ -178,7 +134,7 @@ func TestContextAwareStateHandlerDetection(t *testing.T) {
 	evalCtx := EvaluationContext{}
 
 	t.Run("detects ContextAwareStateHandler", func(t *testing.T) {
-		provider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
+		provider := newTestContextAwareProvider(t, 50*time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
 		defer cancel()
@@ -208,7 +164,7 @@ func TestContextAwareStateHandlerDetection(t *testing.T) {
 	})
 
 	t.Run("handles timeout in context-aware provider", func(t *testing.T) {
-		provider := &testContextAwareProvider{initDelay: 500 * time.Millisecond}
+		provider := newTestContextAwareProvider(t, 500*time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 		defer cancel()
@@ -230,7 +186,7 @@ func TestContextAwareShutdown(t *testing.T) {
 	installIsolatedAPI(t)
 
 	t.Run("context-aware shutdown with timeout", func(t *testing.T) {
-		provider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
+		provider := newTestContextAwareProvider(t, 50*time.Millisecond)
 
 		// Set the provider first
 		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
@@ -242,7 +198,7 @@ func TestContextAwareShutdown(t *testing.T) {
 		}
 
 		// Now replace it to trigger shutdown
-		newProvider := &testContextAwareProvider{initDelay: 10 * time.Millisecond}
+		newProvider := newTestContextAwareProvider(t, 10*time.Millisecond)
 		err = SetProviderWithContextAndWait(ctx, newProvider)
 		if err != nil {
 			t.Errorf("Provider replacement should succeed: %v", err)
@@ -251,7 +207,7 @@ func TestContextAwareShutdown(t *testing.T) {
 
 	t.Run("shutdown timeout handling", func(t *testing.T) {
 		// Create a provider with long shutdown delay that would timeout during shutdown (not init)
-		slowShutdownProvider := &testContextAwareProvider{initDelay: 10 * time.Millisecond} // Fast init
+		slowShutdownProvider := newTestContextAwareProvider(t, 10*time.Millisecond)
 
 		// Set the provider first with generous timeout
 		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -264,7 +220,7 @@ func TestContextAwareShutdown(t *testing.T) {
 
 		// Replace with new provider - shutdown happens in background, so this should succeed
 		// even if the old provider takes a long time to shut down
-		fastProvider := &testContextAwareProvider{initDelay: 10 * time.Millisecond}
+		fastProvider := newTestContextAwareProvider(t, 10*time.Millisecond)
 		err = SetProviderWithContextAndWait(ctx, fastProvider)
 		if err != nil {
 			t.Errorf("Provider replacement should succeed even with slow shutdown: %v", err)
@@ -280,8 +236,8 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 		installIsolatedAPI(t)
 
 		// Set up multiple providers
-		defaultProvider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
-		namedProvider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
+		defaultProvider := newTestContextAwareProvider(t, 50*time.Millisecond)
+		namedProvider := newTestContextAwareProvider(t, 50*time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
@@ -309,10 +265,10 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 	})
 
 	t.Run("shutdown timeout handling", func(t *testing.T) {
-		testAPI := installIsolatedAPI(t)
+		installIsolatedAPI(t)
 
 		// Set up a provider with fast init but simulates long shutdown delay
-		slowShutdownProvider := &testContextAwareProvider{initDelay: 50 * time.Millisecond} // Fast init
+		slowShutdownProvider := newTestContextAwareProvider(t, 50*time.Millisecond, 5*time.Second)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
@@ -322,16 +278,6 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 		if err != nil {
 			t.Errorf("Provider setup should succeed: %v", err)
 		}
-
-		// Create a provider that uses the initDelay for shutdown simulation too
-		// When shutdown is called, it will use the same delay, which would be longer than our timeout
-		// For this test, we'll create a new provider instance with a longer delay to simulate slow shutdown
-		testAPI.mu.Lock()
-		// Replace the provider's delay to simulate slow shutdown
-		if contextProvider, ok := testAPI.defaultProvider.(*testContextAwareProvider); ok {
-			contextProvider.initDelay = 5 * time.Second // This will be used by ShutdownWithContext
-		}
-		testAPI.mu.Unlock()
 
 		// Try to shutdown with short timeout - this should timeout
 		shutdownCtx, shutdownCancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
@@ -376,81 +322,33 @@ func TestGlobalContextAwareShutdown(t *testing.T) {
 			t.Errorf("Global shutdown should succeed with regular providers: %v", err)
 		}
 	})
-}
 
-// testContextAwareProviderWithShutdownDelay allows different delays for init and shutdown
-type testContextAwareProviderWithShutdownDelay struct {
-	initDelay     time.Duration
-	shutdownDelay time.Duration
-}
+	t.Run("named provider shutdown error is returned", func(t *testing.T) {
+		installIsolatedAPI(t)
 
-func (p *testContextAwareProviderWithShutdownDelay) Metadata() Metadata {
-	return Metadata{Name: "test-shutdown-delay-provider"}
-}
+		shutdownErr := errors.New("named provider shutdown failed")
+		provider := newTestContextAwareProvider(t, 10*time.Millisecond)
+		provider.shutdownF = func(context.Context) error { return shutdownErr }
 
-func (p *testContextAwareProviderWithShutdownDelay) InitWithContext(ctx context.Context, evalCtx EvaluationContext) error {
-	select {
-	case <-time.After(p.initDelay):
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		defer cancel()
 
-func (p *testContextAwareProviderWithShutdownDelay) Init(evalCtx EvaluationContext) error {
-	return p.InitWithContext(context.Background(), evalCtx)
-}
+		err := SetNamedProviderWithContextAndWait(ctx, "failing-provider", provider)
+		if err != nil {
+			t.Errorf("Named provider setup should succeed: %v", err)
+		}
 
-func (p *testContextAwareProviderWithShutdownDelay) ShutdownWithContext(ctx context.Context) error {
-	select {
-	case <-time.After(p.shutdownDelay):
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
+		shutdownCtx, shutdownCancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+		defer shutdownCancel()
 
-func (p *testContextAwareProviderWithShutdownDelay) Shutdown() {
-	_ = p.ShutdownWithContext(context.Background())
-}
-
-func (p *testContextAwareProviderWithShutdownDelay) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, flatCtx FlattenedContext) BoolResolutionDetail {
-	return BoolResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProviderWithShutdownDelay) StringEvaluation(ctx context.Context, flag string, defaultValue string, flatCtx FlattenedContext) StringResolutionDetail {
-	return StringResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProviderWithShutdownDelay) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, flatCtx FlattenedContext) FloatResolutionDetail {
-	return FloatResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProviderWithShutdownDelay) IntEvaluation(ctx context.Context, flag string, defaultValue int64, flatCtx FlattenedContext) IntResolutionDetail {
-	return IntResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProviderWithShutdownDelay) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, flatCtx FlattenedContext) InterfaceResolutionDetail {
-	return InterfaceResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testContextAwareProviderWithShutdownDelay) Hooks() []Hook {
-	return []Hook{}
+		err = ShutdownWithContext(shutdownCtx)
+		if err == nil {
+			t.Fatal("Expected shutdown error")
+		}
+		if !errors.Is(err, shutdownErr) {
+			t.Errorf("Expected shutdown error to wrap %v, got: %v", shutdownErr, err)
+		}
+	})
 }
 
 func TestContextPropagationFixes(t *testing.T) {
@@ -458,10 +356,11 @@ func TestContextPropagationFixes(t *testing.T) {
 
 	t.Run("shutdown uses passed context timeout", func(t *testing.T) {
 		// Create provider with fast init but slow shutdown
-		provider := &testContextAwareProviderWithShutdownDelay{
-			initDelay:     10 * time.Millisecond,  // Fast init
-			shutdownDelay: 500 * time.Millisecond, // Slow shutdown
-		}
+		provider := newTestContextAwareProvider(
+			t,
+			10*time.Millisecond,  // Fast init
+			500*time.Millisecond, // Slow shutdown
+		)
 
 		// Set provider with long timeout - should succeed
 		initCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
@@ -473,7 +372,7 @@ func TestContextPropagationFixes(t *testing.T) {
 		}
 
 		// Replace provider with short timeout - shutdown should respect the timeout
-		newProvider := &testContextAwareProvider{initDelay: 10 * time.Millisecond}
+		newProvider := newTestContextAwareProvider(t, 10*time.Millisecond)
 
 		// Use a short timeout that's shorter than the shutdown delay
 		replaceCtx, replaceCancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
@@ -500,10 +399,11 @@ func TestContextPropagationFixes(t *testing.T) {
 	t.Run("shutdown respects context cancellation", func(t *testing.T) {
 		installIsolatedAPI(t)
 
-		provider := &testContextAwareProviderWithShutdownDelay{
-			initDelay:     10 * time.Millisecond,
-			shutdownDelay: 5 * time.Second, // Very slow shutdown
-		}
+		provider := newTestContextAwareProvider(
+			t,
+			10*time.Millisecond,
+			5*time.Second, // Very slow shutdown
+		)
 
 		// Set up provider
 		err := SetProviderWithContextAndWait(t.Context(), provider)
@@ -520,7 +420,7 @@ func TestContextPropagationFixes(t *testing.T) {
 			cancel() // Cancel context during operation
 		}()
 
-		newProvider := &testContextAwareProvider{initDelay: 10 * time.Millisecond}
+		newProvider := newTestContextAwareProvider(t, 10*time.Millisecond)
 		err = SetProviderWithContextAndWait(replaceCtx, newProvider)
 		// Should succeed because init is fast, shutdown is async
 		if err != nil {
@@ -533,7 +433,7 @@ func TestSimplifiedErrorHandling(t *testing.T) {
 	evalCtx := EvaluationContext{}
 
 	t.Run("context cancellation error message", func(t *testing.T) {
-		provider := &testContextAwareProvider{initDelay: 200 * time.Millisecond}
+		provider := newTestContextAwareProvider(t, 200*time.Millisecond)
 
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
@@ -554,7 +454,7 @@ func TestSimplifiedErrorHandling(t *testing.T) {
 	})
 
 	t.Run("context timeout error message", func(t *testing.T) {
-		provider := &testContextAwareProvider{initDelay: 200 * time.Millisecond}
+		provider := newTestContextAwareProvider(t, 200*time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 		defer cancel()
@@ -576,11 +476,22 @@ func TestSimplifiedErrorHandling(t *testing.T) {
 
 	t.Run("provider init error takes precedence", func(t *testing.T) {
 		// Create a provider that returns a ProviderInitError even with context issues
-		provider := &testProviderInitError{
-			initDelay: 50 * time.Millisecond,
-			initError: &ProviderInitError{
-				ErrorCode: ProviderFatalCode,
-				Message:   "Custom provider error",
+		provider := &testContextAwareProvider{
+			FeatureProvider: NoopProvider{},
+			stateContextAwareHandlerForTests: stateContextAwareHandlerForTests{
+				initF: func(ctx context.Context, _ EvaluationContext) error {
+					initError := &ProviderInitError{
+						ErrorCode: ProviderFatalCode,
+						Message:   "Custom provider error",
+					}
+					select {
+					case <-time.After(50 * time.Millisecond):
+						return initError
+					case <-ctx.Done():
+						// Still return the provider error even if context is cancelled
+						return initError
+					}
+				},
 			},
 		}
 
@@ -605,83 +516,14 @@ func TestSimplifiedErrorHandling(t *testing.T) {
 	})
 }
 
-// testProviderInitError is a provider that returns a specific ProviderInitError
-type testProviderInitError struct {
-	initDelay time.Duration
-	initError *ProviderInitError
-}
-
-func (p *testProviderInitError) Metadata() Metadata {
-	return Metadata{Name: "test-provider-init-error"}
-}
-
-func (p *testProviderInitError) InitWithContext(ctx context.Context, evalCtx EvaluationContext) error {
-	select {
-	case <-time.After(p.initDelay):
-		return p.initError
-	case <-ctx.Done():
-		// Still return the provider error even if context is cancelled
-		return p.initError
-	}
-}
-
-func (p *testProviderInitError) Init(evalCtx EvaluationContext) error {
-	return p.InitWithContext(context.Background(), evalCtx)
-}
-
-func (p *testProviderInitError) ShutdownWithContext(ctx context.Context) error {
-	return nil
-}
-
-func (p *testProviderInitError) Shutdown() {}
-
-func (p *testProviderInitError) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, flatCtx FlattenedContext) BoolResolutionDetail {
-	return BoolResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testProviderInitError) StringEvaluation(ctx context.Context, flag string, defaultValue string, flatCtx FlattenedContext) StringResolutionDetail {
-	return StringResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testProviderInitError) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, flatCtx FlattenedContext) FloatResolutionDetail {
-	return FloatResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testProviderInitError) IntEvaluation(ctx context.Context, flag string, defaultValue int64, flatCtx FlattenedContext) IntResolutionDetail {
-	return IntResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testProviderInitError) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, flatCtx FlattenedContext) InterfaceResolutionDetail {
-	return InterfaceResolutionDetail{
-		Value:                    defaultValue,
-		ProviderResolutionDetail: ProviderResolutionDetail{Reason: DefaultReason},
-	}
-}
-
-func (p *testProviderInitError) Hooks() []Hook {
-	return []Hook{}
-}
-
 func TestEdgeCases(t *testing.T) {
 	t.Run("rapid provider switching", func(t *testing.T) {
 		installIsolatedAPI(t)
 
 		providers := []*testContextAwareProvider{
-			{initDelay: 10 * time.Millisecond},
-			{initDelay: 15 * time.Millisecond},
-			{initDelay: 5 * time.Millisecond},
+			newTestContextAwareProvider(t, 10*time.Millisecond),
+			newTestContextAwareProvider(t, 15*time.Millisecond),
+			newTestContextAwareProvider(t, 5*time.Millisecond),
 		}
 
 		// Rapidly switch providers
@@ -710,7 +552,7 @@ func TestEdgeCases(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
 			defer cancel()
 
-			provider := &testContextAwareProvider{initDelay: 50 * time.Millisecond}
+			provider := newTestContextAwareProvider(t, 50*time.Millisecond)
 			err := SetProviderWithContextAndWait(ctx, provider)
 			done <- err
 		}()
@@ -720,7 +562,7 @@ func TestEdgeCases(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
 
-			provider := &testContextAwareProvider{initDelay: 30 * time.Millisecond}
+			provider := newTestContextAwareProvider(t, 30*time.Millisecond)
 			err := SetNamedProviderWithContextAndWait(ctx, "concurrent-test", provider)
 			done <- err
 		}()

--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -382,6 +382,17 @@ func (e *eventExecutor) executeHandler(f func(details EventDetails), event Event
 	}()
 }
 
+// isTracked reports whether p is already tracked in activeSubscriptions.
+func (e *eventExecutor) isTracked(p FeatureProvider) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	ref := newProviderRef(p)
+	if ref.typeOf != nil && ref.typeOf.Comparable() {
+		return isRunning(ref, e.activeSubscriptions)
+	}
+	return false
+}
+
 // isRunning is a helper to check if the given provider is in the given list of providers
 func isRunning(provider providerReference, activeProviders []providerReference) bool {
 	return slices.ContainsFunc(activeProviders, provider.equals)

--- a/openfeature/openfeature_api.go
+++ b/openfeature/openfeature_api.go
@@ -212,6 +212,8 @@ func (a *EvaluationAPI) setProvider(ctx context.Context, provider FeatureProvide
 	oldProvider := a.defaultProvider
 	a.defaultProvider = provider
 
+	tracked := a.eventExecutor.isTracked(provider)
+
 	a.eventExecutor.registerDefaultProvider(provider)
 
 	a.shutdownOld(ctx, oldProvider)
@@ -219,6 +221,14 @@ func (a *EvaluationAPI) setProvider(ctx context.Context, provider FeatureProvide
 	// Unbind the old provider if it is no longer referenced by this API instance.
 	if oldProvider != nil {
 		a.unbindIfUnreferenced(oldProvider)
+	}
+
+	// If the provider is already tracked, it has already been initialized.
+	// Return an already-closed channel so callers can proceed without waiting.
+	if tracked {
+		errCh := make(chan error, 1)
+		close(errCh)
+		return errCh, nil
 	}
 
 	return a.initNew(ctx, "", provider), nil
@@ -240,6 +250,8 @@ func (a *EvaluationAPI) setDomainProvider(ctx context.Context, domain string, pr
 	oldProvider := a.domainProviders[domain]
 	a.domainProviders[domain] = provider
 
+	tracked := a.eventExecutor.isTracked(provider)
+
 	a.eventExecutor.registerNamedEventingProvider(domain, provider)
 
 	a.shutdownOld(ctx, oldProvider)
@@ -247,6 +259,14 @@ func (a *EvaluationAPI) setDomainProvider(ctx context.Context, domain string, pr
 	// Unbind the old provider if it is no longer referenced by this API instance.
 	if oldProvider != nil {
 		a.unbindIfUnreferenced(oldProvider)
+	}
+
+	// If the provider is already tracked, it has already been initialized.
+	// Return an already-closed channel so callers can proceed without waiting.
+	if tracked {
+		errCh := make(chan error, 1)
+		close(errCh)
+		return errCh, nil
 	}
 
 	return a.initNew(ctx, domain, provider), nil
@@ -266,8 +286,9 @@ func (a *EvaluationAPI) initNew(ctx context.Context, domain string, newProvider 
 			} else {
 				err = fmt.Errorf("failed to initialize named provider %q for domain %q: %w", provider.Metadata().Name, domain, err)
 			}
+			errCh <- err
 		}
-		errCh <- err
+		close(errCh)
 	}(a.eventExecutor, a.evalCtx, ctx, newProvider, domain)
 
 	return errCh
@@ -387,25 +408,36 @@ func (a *EvaluationAPI) Shutdown(ctx context.Context) error {
 	defer a.mu.Unlock()
 	var errs []error
 
+	var seen []providerReference
 	// Shutdown default provider
 	if a.defaultProvider != nil {
-		if contextHandler, ok := a.defaultProvider.(ContextAwareStateHandler); ok {
-			if err := contextHandler.ShutdownWithContext(ctx); err != nil {
-				errs = append(errs, fmt.Errorf("default provider shutdown failed: %w", err))
+		if stateHandler, ok := a.defaultProvider.(StateHandler); ok {
+			if contextHandler, ok := stateHandler.(ContextAwareStateHandler); ok {
+				if err := contextHandler.ShutdownWithContext(ctx); err != nil {
+					errs = append(errs, fmt.Errorf("default provider shutdown failed: %w", err))
+				}
+			} else {
+				stateHandler.Shutdown()
 			}
-		} else if stateHandler, ok := a.defaultProvider.(StateHandler); ok {
-			stateHandler.Shutdown()
+			seen = append(seen, newProviderRef(a.defaultProvider))
 		}
 	}
 
 	// Shutdown all named providers
 	for name, provider := range a.domainProviders {
-		if contextHandler, ok := provider.(ContextAwareStateHandler); ok {
-			if err := contextHandler.ShutdownWithContext(ctx); err != nil {
-				errs = append(errs, fmt.Errorf("named provider %q shutdown failed: %w", name, err))
+		if stateHandler, ok := provider.(StateHandler); ok {
+			ref := newProviderRef(provider)
+			if slices.ContainsFunc(seen, ref.equals) {
+				continue
 			}
-		} else if stateHandler, ok := provider.(StateHandler); ok {
-			stateHandler.Shutdown()
+			if contextHandler, ok := provider.(ContextAwareStateHandler); ok {
+				if err := contextHandler.ShutdownWithContext(ctx); err != nil {
+					errs = append(errs, fmt.Errorf("named provider %q shutdown failed: %w", name, err))
+				}
+			} else {
+				stateHandler.Shutdown()
+			}
+			seen = append(seen, ref)
 		}
 	}
 

--- a/openfeature/openfeature_test.go
+++ b/openfeature/openfeature_test.go
@@ -1,8 +1,11 @@
 package openfeature
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -217,6 +220,66 @@ func TestRequirement_1_1_2_3(t *testing.T) {
 
 		// validate
 		expectTimeout(t, shutdownSemA, "shutdown called on the provider with multiple references")
+	})
+
+	t.Run("multibound", func(t *testing.T) {
+		setup := func(t *testing.T) (*EvaluationAPI, FeatureProvider) {
+			t.Helper()
+			inited := atomic.Bool{}
+			shutdown := atomic.Bool{}
+
+			sh := &stateHandlerForTests{
+				initF: func(e EvaluationContext) error {
+					if inited.Swap(true) {
+						return fmt.Errorf("already initialized")
+					}
+					return nil
+				},
+				shutdownF: func() {
+					if shutdown.Swap(true) {
+						t.Fatal("already shutdown")
+					}
+				},
+			}
+			provider := struct {
+				FeatureProvider
+				StateHandler
+			}{
+				FeatureProvider: NoopProvider{},
+				StateHandler:    sh,
+			}
+
+			api := newAPI()
+			t.Cleanup(func() {
+				_ = api.Shutdown(context.Background()) //nolint:usetesting
+			})
+			return api, provider
+		}
+		t.Run("default before domain", func(t *testing.T) {
+			api, provider := setup(t)
+
+			err := api.SetProviderAndWait(t.Context(), provider)
+			if err != nil {
+				t.Errorf("can't set default: %v", err)
+			}
+			err = api.SetProviderAndWait(t.Context(), provider, WithDomain("domain"))
+			if err != nil {
+				t.Errorf("can't set domain: %v", err)
+			}
+		})
+		t.Run("default after domain", func(t *testing.T) {
+			api, provider := setup(t)
+
+			err := api.SetProviderAndWait(t.Context(), provider, WithDomain("domain"))
+			if err != nil {
+				t.Errorf("can't set domain: %v", err)
+			}
+
+			err = api.SetProviderAndWait(t.Context(), provider)
+			if err != nil {
+				t.Errorf("can't set default: %v", err)
+			}
+		})
 	})
 }
 

--- a/openfeature/reference.go
+++ b/openfeature/reference.go
@@ -8,7 +8,7 @@ import (
 func newProviderRef(provider FeatureProvider) providerReference {
 	return providerReference{
 		featureProvider:   provider,
-		kind:              reflect.TypeOf(provider).Kind(),
+		typeOf:            reflect.TypeOf(provider),
 		shutdownSemaphore: make(chan any, 1), // Buffered to allow both send and close operations
 	}
 }
@@ -17,12 +17,25 @@ func newProviderRef(provider FeatureProvider) providerReference {
 // shutdown semaphore
 type providerReference struct {
 	featureProvider   FeatureProvider
-	kind              reflect.Kind
+	typeOf            reflect.Type
 	shutdownSemaphore chan any
 }
 
+// equals reports whether pr and other refer to the same provider.
+//
+// For providers whose dynamic type is comparable, equality is determined using
+// Go's == operator. For non-comparable provider types (such as those containing
+// maps or slices), equality falls back to reflect.DeepEqual.
+//
+// The providers must have the same dynamic type to be considered equal.
 func (pr providerReference) equals(other providerReference) bool {
-	if pr.kind == reflect.Pointer && other.kind == reflect.Pointer {
+	if pr.typeOf == nil {
+		return false
+	}
+	if pr.typeOf != reflect.TypeOf(other.featureProvider) {
+		return false
+	}
+	if pr.typeOf.Comparable() {
 		return pr.featureProvider == other.featureProvider
 	}
 	return reflect.DeepEqual(pr.featureProvider, other.featureProvider)

--- a/openfeature/reference_test.go
+++ b/openfeature/reference_test.go
@@ -10,6 +10,16 @@ func TestProviderReferenceEquals(t *testing.T) {
 		field string
 	}
 
+	type otherProvider struct {
+		NoopProvider
+		field string
+	}
+
+	type nonComparableProvider struct {
+		NoopProvider
+		data map[string]string
+	}
+
 	p1 := myProvider{}
 	p2 := myProvider{}
 
@@ -53,6 +63,40 @@ func TestProviderReferenceEquals(t *testing.T) {
 			name:     "no pointers, different not equal instances",
 			pr1:      newProviderRef(myProvider{field: "A"}),
 			pr2:      newProviderRef(myProvider{field: "B"}),
+			expected: false,
+		},
+		{
+			name: "nil typeOf",
+			pr1: providerReference{
+				featureProvider:   &p1,
+				typeOf:            nil,
+				shutdownSemaphore: make(chan any, 1),
+			},
+			pr2:      newProviderRef(&p1),
+			expected: false,
+		},
+		{
+			name:     "different provider types",
+			pr1:      newProviderRef(myProvider{field: "A"}),
+			pr2:      newProviderRef(otherProvider{field: "A"}),
+			expected: false,
+		},
+		{
+			name:     "non-comparable, equal instances",
+			pr1:      newProviderRef(nonComparableProvider{data: map[string]string{"k": "v"}}),
+			pr2:      newProviderRef(nonComparableProvider{data: map[string]string{"k": "v"}}),
+			expected: true,
+		},
+		{
+			name:     "non-comparable, different instances",
+			pr1:      newProviderRef(nonComparableProvider{data: map[string]string{"k": "v1"}}),
+			pr2:      newProviderRef(nonComparableProvider{data: map[string]string{"k": "v2"}}),
+			expected: false,
+		},
+		{
+			name:     "non-comparable, nil vs empty map",
+			pr1:      newProviderRef(nonComparableProvider{data: nil}),
+			pr2:      newProviderRef(nonComparableProvider{data: map[string]string{}}),
 			expected: false,
 		},
 	}

--- a/openfeature/util_test.go
+++ b/openfeature/util_test.go
@@ -1,6 +1,7 @@
 package openfeature
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -33,6 +34,8 @@ func init() {
 	}
 }
 
+var _ StateHandler = (*stateHandlerForTests)(nil)
+
 // stateHandlerForTests is a StateHandler with callbacks
 type stateHandlerForTests struct {
 	initF     func(e EvaluationContext) error
@@ -50,6 +53,36 @@ func (s *stateHandlerForTests) Shutdown() {
 	if s.shutdownF != nil {
 		s.shutdownF()
 	}
+}
+
+var _ ContextAwareStateHandler = (*stateContextAwareHandlerForTests)(nil)
+
+// stateContextAwareHandlerForTests is a StateHandler with callbacks
+type stateContextAwareHandlerForTests struct {
+	initF     func(context.Context, EvaluationContext) error
+	shutdownF func(context.Context) error
+}
+
+func (s *stateContextAwareHandlerForTests) Init(e EvaluationContext) error {
+	return s.InitWithContext(context.Background(), e)
+}
+
+func (s *stateContextAwareHandlerForTests) InitWithContext(ctx context.Context, e EvaluationContext) error {
+	if s.initF != nil {
+		return s.initF(ctx, e)
+	}
+	return nil
+}
+
+func (s *stateContextAwareHandlerForTests) Shutdown() {
+	_ = s.ShutdownWithContext(context.Background())
+}
+
+func (s *stateContextAwareHandlerForTests) ShutdownWithContext(ctx context.Context) error {
+	if s.shutdownF != nil {
+		return s.shutdownF(ctx)
+	}
+	return nil
 }
 
 // ProviderEventing is an eventing implementation with invoke capability


### PR DESCRIPTION
## This PR

- Allow the same provider instance to be bound as the default provider
  and/or to multiple domains. Reuse the existing initialized provider
  instead of initializing it again.

### Related Issues

Fixes #527
