### PR TITLE
feat: add generic typed accessors for object flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ func main() {
 
 Try this example in the [Go Playground](https://go.dev/play/p/fSSK8s42hA2).
 
+#### Object flags
+
+Object flags can be evaluated directly into a struct with `GetObject`, `GetObjectValue`, and `GetObjectValueDetails`,
+which avoids having to convert the `any` returned by `Client.ObjectValue` yourself:
+
+```go
+type RolloutConfig struct {
+    Text       string `json:"text"`
+    Percentage int    `json:"percentage"`
+}
+
+config, err := openfeature.GetObjectValue(
+    context.TODO(), client, "rollout-config",
+    RolloutConfig{Text: "N/A", Percentage: 75}, openfeature.EvaluationContext{},
+)
+```
+
+If the provider returns a value that cannot be deserialized into the target type, the supplied default value is
+returned along with a `TYPE_MISMATCH` error, consistent with the other typed accessors.
+
 ### API Reference
 
 See [here](https://pkg.go.dev/github.com/open-feature/go-sdk/openfeature) for the complete API documentation.

--- a/openfeature/object.go
+++ b/openfeature/object.go
@@ -1,0 +1,91 @@
+package openfeature
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// GetObject performs an object flag evaluation and returns its value deserialized
+// into T. Any error encountered during the evaluation or the deserialization results
+// in defaultValue being returned. To explicitly handle errors, use [GetObjectValue]
+// or [GetObjectValueDetails].
+func GetObject[T any](
+	ctx context.Context, client *Client, flag string,
+	defaultValue T, evalCtx EvaluationContext, options ...Option,
+) T {
+	value, _ := GetObjectValue(ctx, client, flag, defaultValue, evalCtx, options...)
+
+	return value
+}
+
+// GetObjectValue performs an object flag evaluation and returns its value
+// deserialized into T.
+func GetObjectValue[T any](
+	ctx context.Context, client *Client, flag string,
+	defaultValue T, evalCtx EvaluationContext, options ...Option,
+) (T, error) {
+	details, err := GetObjectValueDetails(ctx, client, flag, defaultValue, evalCtx, options...)
+
+	return details.Value, err
+}
+
+// GetObjectValueDetails performs an object flag evaluation that returns an
+// evaluation details struct whose value is deserialized into T.
+//
+// A value that is already a T is used as-is, otherwise it is round-tripped through
+// JSON. A value that cannot be deserialized into T is abnormal execution:
+// defaultValue is returned with an error reason and a TYPE_MISMATCH error code.
+func GetObjectValueDetails[T any](
+	ctx context.Context, client *Client, flag string,
+	defaultValue T, evalCtx EvaluationContext, options ...Option,
+) (GenericEvaluationDetails[T], error) {
+	evalDetails, err := client.ObjectValueDetails(ctx, flag, defaultValue, evalCtx, options...)
+
+	typedDetails := GenericEvaluationDetails[T]{
+		Value:             defaultValue,
+		EvaluationDetails: evalDetails.EvaluationDetails,
+	}
+	if err != nil {
+		return typedDetails, err
+	}
+
+	// The provider already returned a T; no conversion required.
+	if value, ok := evalDetails.Value.(T); ok {
+		typedDetails.Value = value
+
+		return typedDetails, nil
+	}
+
+	// The provider returned a deserialized structure (e.g. map[string]any).
+	// Round-trip it through JSON to reach T.
+	value, convErr := convertObject[T](evalDetails.Value)
+	if convErr != nil {
+		err := fmt.Errorf("evaluated value is not a %T: %w", defaultValue, convErr)
+		typedDetails.Reason = ErrorReason
+		typedDetails.ErrorCode = TypeMismatchCode
+		typedDetails.ErrorMessage = err.Error()
+
+		return typedDetails, err
+	}
+
+	typedDetails.Value = value
+
+	return typedDetails, nil
+}
+
+// convertObject deserializes value into T by round-tripping it through JSON.
+func convertObject[T any](value any) (T, error) {
+	var converted T
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		return converted, err
+	}
+
+	if err := json.Unmarshal(data, &converted); err != nil {
+		return converted, err
+	}
+
+	return converted, nil
+}

--- a/openfeature/object_example_test.go
+++ b/openfeature/object_example_test.go
@@ -1,0 +1,44 @@
+package openfeature_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+)
+
+type RolloutConfig struct {
+	Text       string `json:"text"`
+	Percentage int    `json:"percentage"`
+}
+
+// This example evaluates an object flag directly into a struct.
+func ExampleGetObjectValue() {
+	provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"rollout-config": {
+			Key:            "rollout-config",
+			State:          memprovider.Enabled,
+			DefaultVariant: "on",
+			Variants: map[string]any{
+				"on": map[string]any{"text": "hello", "percentage": 25},
+			},
+		},
+	})
+	if err := openfeature.SetNamedProviderAndWait("object-example", &provider); err != nil {
+		log.Fatalf("error setting up provider %v", err)
+	}
+	client := openfeature.NewClient("object-example")
+
+	// The flag value is deserialized straight into RolloutConfig.
+	config, err := openfeature.GetObjectValue(
+		context.TODO(), client, "rollout-config", RolloutConfig{Text: "N/A", Percentage: 75}, openfeature.EvaluationContext{},
+	)
+	if err != nil {
+		log.Fatal("error while getting object value : ", err)
+	}
+
+	fmt.Printf("text: %s, percentage: %d", config.Text, config.Percentage)
+	// Output: text: hello, percentage: 25
+}

--- a/openfeature/object_test.go
+++ b/openfeature/object_test.go
@@ -1,0 +1,264 @@
+package openfeature_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/isolated"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+)
+
+// testConfig is the target type for the object evaluations under test. Secret is
+// dropped by JSON, so it survives only when the provider's value is used as-is
+// rather than round-tripped.
+type testConfig struct {
+	Text       string `json:"text"`
+	Percentage int    `json:"percentage"`
+	Secret     string `json:"-"`
+}
+
+// newObjectClient returns a client bound to an isolated API instance serving a
+// single object flag named "config" with the given value, so that tests neither
+// mutate nor leak from the global singleton.
+func newObjectClient(t *testing.T, value any) *openfeature.Client {
+	t.Helper()
+
+	api := isolated.NewAPI()
+	t.Cleanup(func() {
+		if err := api.Shutdown(t.Context()); err != nil {
+			t.Errorf("shutting down isolated api: %v", err)
+		}
+	})
+
+	provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		"config": {
+			Key:            "config",
+			State:          memprovider.Enabled,
+			DefaultVariant: "default",
+			Variants:       map[string]any{"default": value},
+		},
+	})
+	if err := api.SetProviderAndWait(t.Context(), &provider); err != nil {
+		t.Fatalf("setting provider: %v", err)
+	}
+
+	return api.NewClient()
+}
+
+// TestRequirement_1_3_4 The client SHOULD guarantee the returned value of any typed flag
+// evaluation method is of the expected type. If the value returned by the underlying
+// provider implementation does not match the expected type, it's to be considered abnormal
+// execution, and the supplied default value should be returned.
+func TestRequirement_1_3_4(t *testing.T) {
+	defaultValue := testConfig{Text: "N/A", Percentage: 75}
+
+	tests := map[string]struct {
+		value       any
+		flag        string
+		want        testConfig
+		wantErr     bool
+		wantCode    openfeature.ErrorCode
+		wantReason  openfeature.Reason
+		wantVariant string
+	}{
+		"value of the target type is used as-is": {
+			value:       testConfig{Text: "hello", Percentage: 25, Secret: "kept"},
+			want:        testConfig{Text: "hello", Percentage: 25, Secret: "kept"},
+			wantReason:  openfeature.StaticReason,
+			wantVariant: "default",
+		},
+		"structure is round-tripped through JSON": {
+			value:       map[string]any{"text": "hello", "percentage": 25, "secret": "dropped"},
+			want:        testConfig{Text: "hello", Percentage: 25},
+			wantReason:  openfeature.StaticReason,
+			wantVariant: "default",
+		},
+		"value that cannot be unmarshalled returns the default value": {
+			value:       "not-an-object",
+			want:        defaultValue,
+			wantErr:     true,
+			wantCode:    openfeature.TypeMismatchCode,
+			wantReason:  openfeature.ErrorReason,
+			wantVariant: "default",
+		},
+		// Channels are not serializable, so the round-trip fails at marshal time.
+		"value that cannot be marshalled returns the default value": {
+			value:       make(chan int),
+			want:        defaultValue,
+			wantErr:     true,
+			wantCode:    openfeature.TypeMismatchCode,
+			wantReason:  openfeature.ErrorReason,
+			wantVariant: "default",
+		},
+		"failed evaluation returns the default value": {
+			value:      testConfig{Text: "hello", Percentage: 25},
+			flag:       "missing",
+			want:       defaultValue,
+			wantErr:    true,
+			wantCode:   openfeature.FlagNotFoundCode,
+			wantReason: openfeature.ErrorReason,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := newObjectClient(t, test.value)
+
+			flag := test.flag
+			if flag == "" {
+				flag = "config"
+			}
+
+			details, err := openfeature.GetObjectValueDetails(
+				t.Context(), client, flag, defaultValue, openfeature.EvaluationContext{},
+			)
+
+			switch {
+			case test.wantErr && err == nil:
+				t.Fatal("got nil error, want an error")
+			case !test.wantErr && err != nil:
+				t.Fatalf("got error %v, want nil", err)
+			}
+
+			if details.Value != test.want {
+				t.Errorf("got value %+v, want %+v", details.Value, test.want)
+			}
+			if details.ErrorCode != test.wantCode {
+				t.Errorf("got error code %q, want %q", details.ErrorCode, test.wantCode)
+			}
+			if test.wantErr && details.ErrorMessage == "" {
+				t.Error("got empty error message, want a message")
+			}
+			if details.Reason != test.wantReason {
+				t.Errorf("got reason %q, want %q", details.Reason, test.wantReason)
+			}
+
+			// Resolution metadata is carried on every return path.
+			if details.FlagKey != flag {
+				t.Errorf("got flag key %q, want %q", details.FlagKey, flag)
+			}
+			if details.FlagType != openfeature.Object {
+				t.Errorf("got flag type %v, want %v", details.FlagType, openfeature.Object)
+			}
+			if details.Variant != test.wantVariant {
+				t.Errorf("got variant %q, want %q", details.Variant, test.wantVariant)
+			}
+		})
+	}
+}
+
+// TestGetObjectValueDetailsForAny verifies that a value is returned untouched when
+// the target type imposes no constraint.
+func TestGetObjectValueDetailsForAny(t *testing.T) {
+	client := newObjectClient(t, map[string]any{"text": "hello"})
+
+	details, err := openfeature.GetObjectValueDetails[any](
+		t.Context(), client, "config", nil, openfeature.EvaluationContext{},
+	)
+	if err != nil {
+		t.Fatalf("got error %v, want nil", err)
+	}
+
+	value, ok := details.Value.(map[string]any)
+	if !ok {
+		t.Fatalf("got value of type %T, want map[string]any", details.Value)
+	}
+	if value["text"] != "hello" {
+		t.Errorf("got text %v, want hello", value["text"])
+	}
+}
+
+// TestGetObjectValueDetailsForwardsOptions verifies that evaluation options reach
+// the underlying evaluation.
+func TestGetObjectValueDetailsForwardsOptions(t *testing.T) {
+	client := newObjectClient(t, testConfig{Text: "hello", Percentage: 25})
+
+	hook := &recordingHook{}
+	if _, err := openfeature.GetObjectValueDetails(
+		t.Context(), client, "config", testConfig{}, openfeature.EvaluationContext{},
+		openfeature.WithHooks(hook),
+	); err != nil {
+		t.Fatalf("got error %v, want nil", err)
+	}
+
+	if !hook.called {
+		t.Error("got an unexecuted invocation hook, want it executed")
+	}
+}
+
+func TestGetObjectValue(t *testing.T) {
+	defaultValue := testConfig{Text: "N/A", Percentage: 75}
+	stored := testConfig{Text: "hello", Percentage: 25}
+
+	tests := map[string]struct {
+		flag    string
+		want    testConfig
+		wantErr bool
+	}{
+		"returns the value":                       {flag: "config", want: stored},
+		"returns the default value and the error": {flag: "missing", want: defaultValue, wantErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := newObjectClient(t, stored)
+
+			got, err := openfeature.GetObjectValue(
+				t.Context(), client, test.flag, defaultValue, openfeature.EvaluationContext{},
+			)
+
+			switch {
+			case test.wantErr && err == nil:
+				t.Fatal("got nil error, want an error")
+			case !test.wantErr && err != nil:
+				t.Fatalf("got error %v, want nil", err)
+			}
+
+			if got != test.want {
+				t.Errorf("got %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGetObject(t *testing.T) {
+	defaultValue := testConfig{Text: "N/A", Percentage: 75}
+	stored := testConfig{Text: "hello", Percentage: 25}
+
+	tests := map[string]struct {
+		flag string
+		want testConfig
+	}{
+		"returns the value":                          {flag: "config", want: stored},
+		"swallows the error and returns the default": {flag: "missing", want: defaultValue},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client := newObjectClient(t, stored)
+
+			got := openfeature.GetObject(
+				t.Context(), client, test.flag, defaultValue, openfeature.EvaluationContext{},
+			)
+			if got != test.want {
+				t.Errorf("got %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+// recordingHook records whether it was invoked.
+type recordingHook struct {
+	openfeature.UnimplementedHook
+
+	called bool
+}
+
+func (h *recordingHook) Before(
+	ctx context.Context, hookContext openfeature.HookContext, hookHints openfeature.HookHints,
+) (*openfeature.EvaluationContext, error) {
+	h.called = true
+
+	return nil, nil
+}


### PR DESCRIPTION
Closes #535.

Adds `GetObject`, `GetObjectValue`, and `GetObjectValueDetails` — package-level generic functions that evaluate an object flag and deserialize the result into a caller-supplied `T` instead of returning `any`.

`Client.ObjectValue` returns `any`, which for most providers is a `map[string]any`, so callers re-marshal it into their own struct. This does that once, in the SDK:

```go
config, err := openfeature.GetObjectValue(
    ctx, client, "rollout-config",
    RolloutConfig{Text: "N/A", Percentage: 75}, openfeature.EvaluationContext{},
)
```

If the provider already returns a `T` it is used as-is; otherwise the value is round-tripped through JSON. A value that can't be deserialized returns the default with a `TYPE_MISMATCH` error code, per [1.3.4](https://openfeature.dev/specification/sections/flag-evaluation#requirement-134) and consistent with the existing typed accessors.

## Notes for reviewers

- **Functions, not methods.** Go interfaces can't declare type parameters, so this can't live on `IClient`. Go 1.27 allows generic methods on concrete types, but `go.mod` is on 1.26 and the two shapes compose, so a method can follow later with nothing to undo.
- **Purely additive.** No signatures change. `ObjectValue`/`ObjectValueDetails` stay, and remain the only way to pass a bare `nil` default.
- **Error handling.** A conversion failure sets `Reason` to `ERROR` alongside `TYPE_MISMATCH`, per [1.4.9](https://openfeature.dev/specification/sections/flag-evaluation#requirement-149) and matching what `Client.evaluate` already does for provider errors. Note the existing typed accessors (`StringValueDetails` and friends) leave `Reason` untouched on their type-assertion failure path, so they can return a default value still labelled `STATIC` — a pre-existing gap worth fixing separately.
- **Hook ordering.** Conversion happens after `evaluate`, so `After` hooks see the raw value — same as the existing typed accessors.
- No new dependencies; stdlib `encoding/json` only.

Tests cover the fast path, the `map[string]any` fallback, `T` of `any`, marshal and unmarshal failures, metadata and error propagation, and `...Option` forwarding. Also adds `ExampleGetObjectValue` and a README section.
