### PR TITLE
fix: set ErrorReason when typed accessors return TYPE_MISMATCH

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -373,15 +373,7 @@ func (c *Client) BooleanValueDetails(ctx context.Context, flag string, defaultVa
 
 	value, ok := evalDetails.Value.(bool)
 	if !ok {
-		err := errors.New("evaluated value is not a boolean")
-		boolEvalDetails := BooleanEvaluationDetails{
-			Value:             defaultValue,
-			EvaluationDetails: evalDetails.EvaluationDetails,
-		}
-		boolEvalDetails.ErrorCode = TypeMismatchCode
-		boolEvalDetails.ErrorMessage = err.Error()
-
-		return boolEvalDetails, err
+		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errors.New("evaluated value is not a boolean"))
 	}
 
 	return BooleanEvaluationDetails{
@@ -417,15 +409,7 @@ func (c *Client) StringValueDetails(ctx context.Context, flag string, defaultVal
 
 	value, ok := evalDetails.Value.(string)
 	if !ok {
-		err := errors.New("evaluated value is not a string")
-		strEvalDetails := StringEvaluationDetails{
-			Value:             defaultValue,
-			EvaluationDetails: evalDetails.EvaluationDetails,
-		}
-		strEvalDetails.ErrorCode = TypeMismatchCode
-		strEvalDetails.ErrorMessage = err.Error()
-
-		return strEvalDetails, err
+		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errors.New("evaluated value is not a string"))
 	}
 
 	return StringEvaluationDetails{
@@ -461,15 +445,7 @@ func (c *Client) FloatValueDetails(ctx context.Context, flag string, defaultValu
 
 	value, ok := evalDetails.Value.(float64)
 	if !ok {
-		err := errors.New("evaluated value is not a float64")
-		floatEvalDetails := FloatEvaluationDetails{
-			Value:             defaultValue,
-			EvaluationDetails: evalDetails.EvaluationDetails,
-		}
-		floatEvalDetails.ErrorCode = TypeMismatchCode
-		floatEvalDetails.ErrorMessage = err.Error()
-
-		return floatEvalDetails, err
+		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errors.New("evaluated value is not a float64"))
 	}
 
 	return FloatEvaluationDetails{
@@ -505,15 +481,7 @@ func (c *Client) IntValueDetails(ctx context.Context, flag string, defaultValue 
 
 	value, ok := evalDetails.Value.(int64)
 	if !ok {
-		err := errors.New("evaluated value is not an int64")
-		intEvalDetails := IntEvaluationDetails{
-			Value:             defaultValue,
-			EvaluationDetails: evalDetails.EvaluationDetails,
-		}
-		intEvalDetails.ErrorCode = TypeMismatchCode
-		intEvalDetails.ErrorMessage = err.Error()
-
-		return intEvalDetails, err
+		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errors.New("evaluated value is not an int64"))
 	}
 
 	return IntEvaluationDetails{
@@ -540,6 +508,21 @@ func (c *Client) ObjectValueDetails(ctx context.Context, flag string, defaultVal
 	}
 
 	return c.evaluate(ctx, flag, Object, defaultValue, evalCtx, *evalOptions)
+}
+
+// typeMismatchDetails builds the details a typed accessor returns when the resolved value is not of
+// its type. The default value replaces the resolved one, so the reason reports an error rather than
+// the provider's reason for a value that is not being returned.
+func typeMismatchDetails[T any](defaultValue T, resolved EvaluationDetails, err error) (GenericEvaluationDetails[T], error) {
+	details := GenericEvaluationDetails[T]{
+		Value:             defaultValue,
+		EvaluationDetails: resolved,
+	}
+	details.Reason = ErrorReason
+	details.ErrorCode = TypeMismatchCode
+	details.ErrorMessage = err.Error()
+
+	return details, err
 }
 
 // Boolean performs a flag evaluation that returns a boolean. Any error

--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -49,6 +49,14 @@ type Client struct {
 // interface guard to ensure that Client implements IClient
 var _ IClient = (*Client)(nil)
 
+// errors returned by the typed accessors when the resolved value is not of their type
+var (
+	errNotBoolean = errors.New("evaluated value is not a boolean")
+	errNotString  = errors.New("evaluated value is not a string")
+	errNotFloat64 = errors.New("evaluated value is not a float64")
+	errNotInt64   = errors.New("evaluated value is not an int64")
+)
+
 // NewClient returns a new [Client] bound to the provider registered for the given domain.
 func NewClient(domain string) *Client {
 	return api().NewClient(WithDomain(domain))
@@ -373,7 +381,7 @@ func (c *Client) BooleanValueDetails(ctx context.Context, flag string, defaultVa
 
 	value, ok := evalDetails.Value.(bool)
 	if !ok {
-		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errors.New("evaluated value is not a boolean"))
+		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errNotBoolean)
 	}
 
 	return BooleanEvaluationDetails{
@@ -409,7 +417,7 @@ func (c *Client) StringValueDetails(ctx context.Context, flag string, defaultVal
 
 	value, ok := evalDetails.Value.(string)
 	if !ok {
-		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errors.New("evaluated value is not a string"))
+		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errNotString)
 	}
 
 	return StringEvaluationDetails{
@@ -445,7 +453,7 @@ func (c *Client) FloatValueDetails(ctx context.Context, flag string, defaultValu
 
 	value, ok := evalDetails.Value.(float64)
 	if !ok {
-		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errors.New("evaluated value is not a float64"))
+		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errNotFloat64)
 	}
 
 	return FloatEvaluationDetails{
@@ -481,7 +489,7 @@ func (c *Client) IntValueDetails(ctx context.Context, flag string, defaultValue 
 
 	value, ok := evalDetails.Value.(int64)
 	if !ok {
-		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errors.New("evaluated value is not an int64"))
+		return typeMismatchDetails(defaultValue, evalDetails.EvaluationDetails, errNotInt64)
 	}
 
 	return IntEvaluationDetails{

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -110,6 +112,63 @@ func TestRequirements_1_3(t *testing.T) {
 	}
 }
 
+// If the value returned by the underlying provider implementation does not match the expected type,
+// it's to be considered abnormal execution, and the supplied `default value` should be returned.
+// Abnormal execution means the `reason` indicates an error (requirement 1.4.9) rather than the
+// reason for the resolution whose value was discarded.
+//
+// The accessors' type assertions can't fail through a FeatureProvider, since evaluate takes its
+// value from the statically typed provider results, so the shared helper is exercised directly.
+func TestRequirement_1_3_4(t *testing.T) {
+	// A successful resolution carrying a value that is not of the accessor's type.
+	resolved := EvaluationDetails{
+		FlagKey:          "foo",
+		ResolutionDetail: ResolutionDetail{Variant: "mismatched", Reason: StaticReason},
+	}
+	mismatchErr := errors.New("evaluated value is of the wrong type")
+
+	tests := map[string]struct {
+		want     any
+		mismatch func() (InterfaceEvaluationDetails, error)
+	}{
+		"boolean": {booleanValue, func() (InterfaceEvaluationDetails, error) {
+			return anyDetails(typeMismatchDetails(booleanValue, resolved, mismatchErr))
+		}},
+		"string": {stringValue, func() (InterfaceEvaluationDetails, error) {
+			return anyDetails(typeMismatchDetails(stringValue, resolved, mismatchErr))
+		}},
+		"float64": {floatValue, func() (InterfaceEvaluationDetails, error) {
+			return anyDetails(typeMismatchDetails(floatValue, resolved, mismatchErr))
+		}},
+		"int64": {int64(intValue), func() (InterfaceEvaluationDetails, error) {
+			return anyDetails(typeMismatchDetails(int64(intValue), resolved, mismatchErr))
+		}},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			details, err := tt.mismatch()
+
+			require.ErrorIs(t, err, mismatchErr)
+			assert.Equal(t, tt.want, details.Value)
+			assert.Equal(t, EvaluationDetails{
+				FlagKey: resolved.FlagKey,
+				ResolutionDetail: ResolutionDetail{
+					Variant:      resolved.Variant,
+					Reason:       ErrorReason,
+					ErrorCode:    TypeMismatchCode,
+					ErrorMessage: mismatchErr.Error(),
+				},
+			}, details.EvaluationDetails)
+		})
+	}
+}
+
+// anyDetails erases the type parameter so cases for different types can share one table.
+func anyDetails[T any](details GenericEvaluationDetails[T], err error) (InterfaceEvaluationDetails, error) {
+	return InterfaceEvaluationDetails{Value: details.Value, EvaluationDetails: details.EvaluationDetails}, err
+}
+
 // The `client` MUST provide methods for detailed flag value evaluation with parameters `flag key` (string, required),
 // `default value` (boolean | number | string | structure, required), `evaluation context` (optional),
 // and `evaluation options` (optional), which returns an `evaluation details` structure.
@@ -186,7 +245,13 @@ func TestRequirement_1_4_2__1_4_5__1_4_6(t *testing.T) {
 			t.Error(err)
 		}
 		if evDetails.Value != booleanValue {
-			t.Error(err)
+			t.Error(incorrectValue)
+		}
+		if evDetails.Variant != booleanVariant {
+			t.Error(incorrectVariant)
+		}
+		if evDetails.Reason != testReason {
+			t.Error(incorrectReason)
 		}
 	})
 


### PR DESCRIPTION
Closes #537.

The typed detail accessors copy the provider's `EvaluationDetails` verbatim when their type assertion fails. They overwrite `ErrorCode` and `ErrorMessage` but not `Reason`, so a result holding the caller's *default* value could still report a successful reason such as `STATIC`.

Spec [1.3.4](https://openfeature.dev/specification/sections/flag-evaluation#requirement-134) calls a type mismatch abnormal execution, and [1.4.9](https://openfeature.dev/specification/sections/flag-evaluation#requirement-149) says `reason` should then indicate an error — which is what `Client.evaluate`, `multi`, and `memprovider` already do.

The four mismatch blocks were identical apart from type and message, so they're now one generic helper that sets `Reason = ErrorReason` in one place. Error codes and messages are unchanged.

## Notes for reviewers

- **These branches are unreachable today.** `evaluate` takes its value from statically typed provider results (`BoolResolutionDetail` wraps a `bool`), so no `FeatureProvider` can make `evalDetails.Value.(bool)` fail. They're defensive code — which is why nothing tested them, and why the test drives the helper rather than a provider mock. Verified it fails on `STATIC` without the fix.
- **The e2e step is dormant.** `theReasonShouldIndicateAnErrorAndTheErrorCodeShouldIndicateATypeMismatchWith` already asserts `ErrorReason`, but reaches TYPE_MISMATCH via the provider-error path, and its scenario is no longer in the current `test-harness` `evaluation.feature`.
- **`ObjectValueDetails` is untouched** — no assertion, so no client-side mismatch to fix.
- **Adjacent gap, not fixed here:** `evaluate`'s other error exits (invalid UTF-8 key, NOT_READY/FATAL, hook errors) leave `Reason` empty rather than `ErrorReason`. Happy to open a separate issue.
- Also filled in the missing `Variant`/`Reason` assertions in the `BooleanValueDetails` happy-path subtest, which its four siblings already had.

`make test`, `make e2e-test` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
