### PR TITLE
feat: support updating the in-memory provider's flag set

### DIFF
--- a/openfeature/memprovider/README.md
+++ b/openfeature/memprovider/README.md
@@ -3,3 +3,26 @@
 `InMemoryProvider` is an OpenFeature compliant provider implementation with an in-memory flag storage. 
 
 While the main usage of this provider is SDK testing, you may use it for minimal OpenFeature use cases where appropriate.
+
+## Updating flags
+
+`UpdateFlags` replaces the flag set and emits a `PROVIDER_CONFIGURATION_CHANGED`
+event listing the union of the previous and the new flag keys:
+
+```go
+provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+    "my-flag": {Key: "my-flag", State: memprovider.Enabled, DefaultVariant: "on", Variants: map[string]any{"on": true, "off": false}},
+})
+if err := openfeature.SetProviderAndWait(provider); err != nil {
+    // handle err
+}
+
+// handlers registered for openfeature.ProviderConfigChange are invoked
+provider.UpdateFlags(map[string]memprovider.InMemoryFlag{
+    "my-flag": {Key: "my-flag", State: memprovider.Enabled, DefaultVariant: "off", Variants: map[string]any{"on": true, "off": false}},
+})
+```
+
+The provider must be held as `*InMemoryProvider`, which is what
+`NewInMemoryProvider` returns. The event is dropped rather than blocking when the
+provider is not registered with an API, since nothing is listening.

--- a/openfeature/memprovider/README.md
+++ b/openfeature/memprovider/README.md
@@ -26,3 +26,12 @@ provider.UpdateFlags(map[string]memprovider.InMemoryFlag{
 The provider must be held as `*InMemoryProvider`, which is what
 `NewInMemoryProvider` returns. The event is dropped rather than blocking when the
 provider is not registered with an API, since nothing is listening.
+
+### Flag ownership
+
+Both `NewInMemoryProvider` and `UpdateFlags` copy the map they are given, so
+mutating it afterwards does not affect the provider. The copy is shallow: the
+provider takes ownership of each flag's `Variants` and `ContextEvaluator`, which
+must not be mutated once the flag has been handed over. `UpdateFlags` is the
+only supported way to change the flag set — it is what emits the
+`PROVIDER_CONFIGURATION_CHANGED` event.

--- a/openfeature/memprovider/README.md
+++ b/openfeature/memprovider/README.md
@@ -24,8 +24,9 @@ provider.UpdateFlags(map[string]memprovider.InMemoryFlag{
 ```
 
 The provider must be held as `*InMemoryProvider`, which is what
-`NewInMemoryProvider` returns. The event is dropped rather than blocking when the
-provider is not registered with an API, since nothing is listening.
+`NewInMemoryProvider` returns. Events are buffered, so up to five updates made
+before the provider is registered are still delivered once it is; past that,
+events are dropped rather than blocking the caller.
 
 ### Flag ownership
 

--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -187,20 +187,15 @@ func (i *InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.Provid
 // with an API.
 func (i *InMemoryProvider) UpdateFlags(flags map[string]InMemoryFlag) {
 	i.mu.Lock()
-	changed := make([]string, 0, len(i.flags)+len(flags))
-	for key := range i.flags {
-		changed = append(changed, key)
-	}
-	for key := range flags {
-		if _, ok := i.flags[key]; !ok {
-			changed = append(changed, key)
-		}
-	}
+	changed := slices.AppendSeq(slices.Collect(maps.Keys(i.flags)), maps.Keys(flags))
 	// Readers keep an immutable snapshot; the caller's map is never retained.
 	i.flags = maps.Clone(flags)
 	i.mu.Unlock()
 
+	// Sorting makes the union deterministic and puts any key present in both
+	// the old and the new set next to its duplicate for Compact to drop.
 	slices.Sort(changed)
+	changed = slices.Compact(changed)
 
 	select {
 	case i.events <- openfeature.Event{

--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -4,6 +4,9 @@ package memprovider
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
+	"sync"
 
 	"github.com/open-feature/go-sdk/openfeature"
 )
@@ -13,25 +16,40 @@ const (
 	Disabled State = "DISABLED"
 )
 
+const providerName = "InMemoryProvider"
+
+// eventChannelBuffer absorbs bursts of events. A registered provider is drained
+// continuously by the SDK's event executor.
+const eventChannelBuffer = 5
+
+var (
+	_ openfeature.FeatureProvider = (*InMemoryProvider)(nil)
+	_ openfeature.EventHandler    = (*InMemoryProvider)(nil)
+	_ openfeature.Tracker         = (*InMemoryProvider)(nil)
+)
+
 type InMemoryProvider struct {
+	mu             sync.RWMutex
 	flags          map[string]InMemoryFlag
 	trackingEvents map[string][]InMemoryEvent
+	events         chan openfeature.Event
 }
 
-func NewInMemoryProvider(from map[string]InMemoryFlag) InMemoryProvider {
-	return InMemoryProvider{
-		flags:          from,
+func NewInMemoryProvider(from map[string]InMemoryFlag) *InMemoryProvider {
+	return &InMemoryProvider{
+		flags:          maps.Clone(from),
 		trackingEvents: map[string][]InMemoryEvent{},
+		events:         make(chan openfeature.Event, eventChannelBuffer),
 	}
 }
 
-func (i InMemoryProvider) Metadata() openfeature.Metadata {
+func (i *InMemoryProvider) Metadata() openfeature.Metadata {
 	return openfeature.Metadata{
-		Name: "InMemoryProvider",
+		Name: providerName,
 	}
 }
 
-func (i InMemoryProvider) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, flatCtx openfeature.FlattenedContext) openfeature.BoolResolutionDetail {
+func (i *InMemoryProvider) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, flatCtx openfeature.FlattenedContext) openfeature.BoolResolutionDetail {
 	memoryFlag, details, ok := i.find(flag)
 	if !ok {
 		return openfeature.BoolResolutionDetail{
@@ -49,7 +67,7 @@ func (i InMemoryProvider) BooleanEvaluation(ctx context.Context, flag string, de
 	}
 }
 
-func (i InMemoryProvider) StringEvaluation(ctx context.Context, flag string, defaultValue string, flatCtx openfeature.FlattenedContext) openfeature.StringResolutionDetail {
+func (i *InMemoryProvider) StringEvaluation(ctx context.Context, flag string, defaultValue string, flatCtx openfeature.FlattenedContext) openfeature.StringResolutionDetail {
 	memoryFlag, details, ok := i.find(flag)
 	if !ok {
 		return openfeature.StringResolutionDetail{
@@ -67,7 +85,7 @@ func (i InMemoryProvider) StringEvaluation(ctx context.Context, flag string, def
 	}
 }
 
-func (i InMemoryProvider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, flatCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
+func (i *InMemoryProvider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, flatCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
 	memoryFlag, details, ok := i.find(flag)
 	if !ok {
 		return openfeature.FloatResolutionDetail{
@@ -85,7 +103,7 @@ func (i InMemoryProvider) FloatEvaluation(ctx context.Context, flag string, defa
 	}
 }
 
-func (i InMemoryProvider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, flatCtx openfeature.FlattenedContext) openfeature.IntResolutionDetail {
+func (i *InMemoryProvider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, flatCtx openfeature.FlattenedContext) openfeature.IntResolutionDetail {
 	memoryFlag, details, ok := i.find(flag)
 	if !ok {
 		return openfeature.IntResolutionDetail{
@@ -103,7 +121,7 @@ func (i InMemoryProvider) IntEvaluation(ctx context.Context, flag string, defaul
 	}
 }
 
-func (i InMemoryProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, flatCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+func (i *InMemoryProvider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, flatCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
 	memoryFlag, details, ok := i.find(flag)
 	if !ok {
 		return openfeature.InterfaceResolutionDetail{
@@ -129,11 +147,14 @@ func (i InMemoryProvider) ObjectEvaluation(ctx context.Context, flag string, def
 	}
 }
 
-func (i InMemoryProvider) Hooks() []openfeature.Hook {
+func (i *InMemoryProvider) Hooks() []openfeature.Hook {
 	return []openfeature.Hook{}
 }
 
-func (i InMemoryProvider) Track(ctx context.Context, trackingEventName string, evalCtx openfeature.EvaluationContext, details openfeature.TrackingEventDetails) {
+func (i *InMemoryProvider) Track(ctx context.Context, trackingEventName string, evalCtx openfeature.EvaluationContext, details openfeature.TrackingEventDetails) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	i.trackingEvents[trackingEventName] = append(i.trackingEvents[trackingEventName], InMemoryEvent{
 		Value:             details.Value(),
 		Data:              details.Attributes(),
@@ -141,8 +162,11 @@ func (i InMemoryProvider) Track(ctx context.Context, trackingEventName string, e
 	})
 }
 
-func (i InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.ProviderResolutionDetail, bool) {
+func (i *InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.ProviderResolutionDetail, bool) {
+	i.mu.RLock()
 	memoryFlag, ok := i.flags[flag]
+	i.mu.RUnlock()
+
 	if !ok {
 		return nil,
 			&openfeature.ProviderResolutionDetail{
@@ -152,6 +176,50 @@ func (i InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.Provide
 	}
 
 	return &memoryFlag, nil, true
+}
+
+// UpdateFlags replaces the flag set and emits a PROVIDER_CONFIGURATION_CHANGED
+// event naming the union of the previous and the new flag keys, as required by
+// Appendix A of the OpenFeature specification.
+//
+// The event is dropped rather than blocking the caller when nothing is draining
+// the event channel, which is the case while the provider is not registered
+// with an API.
+func (i *InMemoryProvider) UpdateFlags(flags map[string]InMemoryFlag) {
+	i.mu.Lock()
+	changed := make([]string, 0, len(i.flags)+len(flags))
+	for key := range i.flags {
+		changed = append(changed, key)
+	}
+	for key := range flags {
+		if _, ok := i.flags[key]; !ok {
+			changed = append(changed, key)
+		}
+	}
+	// Readers keep an immutable snapshot; the caller's map is never retained.
+	i.flags = maps.Clone(flags)
+	i.mu.Unlock()
+
+	slices.Sort(changed)
+
+	select {
+	case i.events <- openfeature.Event{
+		ProviderName: providerName,
+		EventType:    openfeature.ProviderConfigChange,
+		ProviderEventDetails: openfeature.ProviderEventDetails{
+			Message:     "flag configuration changed",
+			FlagChanges: changed,
+		},
+	}:
+	default:
+	}
+}
+
+// EventChannel implements openfeature.EventHandler. The channel is never closed:
+// the SDK stops listening via its own shutdown signal, and closing would panic a
+// subsequent UpdateFlags.
+func (i *InMemoryProvider) EventChannel() <-chan openfeature.Event {
+	return i.events
 }
 
 // helpers

--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -197,12 +197,14 @@ func (i *InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.Provid
 // still delivered once the SDK attaches a listener. Once the buffer is full the
 // event is dropped rather than blocking the caller.
 func (i *InMemoryProvider) UpdateFlags(flags map[string]InMemoryFlag) {
+	// Readers keep an immutable snapshot; the caller's map is never retained.
+	flags = maps.Clone(flags)
+
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
 	changed := slices.AppendSeq(slices.Collect(maps.Keys(i.flags)), maps.Keys(flags))
-	// Readers keep an immutable snapshot; the caller's map is never retained.
-	i.flags = maps.Clone(flags)
+	i.flags = flags
 
 	// Sorting makes the union deterministic and puts any key present in both
 	// the old and the new set next to its duplicate for Compact to drop.

--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -18,8 +18,9 @@ const (
 
 const providerName = "InMemoryProvider"
 
-// eventChannelBuffer absorbs bursts of events. A registered provider is drained
-// continuously by the SDK's event executor.
+// eventChannelBuffer absorbs bursts of events, and holds events emitted before
+// the provider is registered. A registered provider is drained continuously by
+// the SDK's event executor. Events emitted once the buffer is full are dropped.
 const eventChannelBuffer = 5
 
 var (
@@ -192,21 +193,24 @@ func (i *InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.Provid
 // ownership of each flag's Variants and ContextEvaluator, which must not be
 // mutated once the flag has been handed over.
 //
-// The event is dropped rather than blocking the caller when nothing is draining
-// the event channel, which is the case while the provider is not registered
-// with an API.
+// Events are buffered, so an update made before the provider is registered is
+// still delivered once the SDK attaches a listener. Once the buffer is full the
+// event is dropped rather than blocking the caller.
 func (i *InMemoryProvider) UpdateFlags(flags map[string]InMemoryFlag) {
 	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	changed := slices.AppendSeq(slices.Collect(maps.Keys(i.flags)), maps.Keys(flags))
 	// Readers keep an immutable snapshot; the caller's map is never retained.
 	i.flags = maps.Clone(flags)
-	i.mu.Unlock()
 
 	// Sorting makes the union deterministic and puts any key present in both
 	// the old and the new set next to its duplicate for Compact to drop.
 	slices.Sort(changed)
 	changed = slices.Compact(changed)
 
+	// Emitting under the lock keeps the event order agreeing with the order the
+	// flag sets were applied; the send cannot block, so it cannot deadlock.
 	select {
 	case i.events <- openfeature.Event{
 		ProviderName: providerName,

--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -35,6 +35,12 @@ type InMemoryProvider struct {
 	events         chan openfeature.Event
 }
 
+// NewInMemoryProvider returns a provider serving a copy of the given flag set.
+//
+// The map itself is copied, so mutating it afterwards does not affect the
+// provider. The copy is shallow: the provider takes ownership of each flag's
+// Variants and ContextEvaluator, which must not be mutated once the flag has
+// been handed over. Use [InMemoryProvider.UpdateFlags] to change the flag set.
 func NewInMemoryProvider(from map[string]InMemoryFlag) *InMemoryProvider {
 	return &InMemoryProvider{
 		flags:          maps.Clone(from),
@@ -181,6 +187,10 @@ func (i *InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.Provid
 // UpdateFlags replaces the flag set and emits a PROVIDER_CONFIGURATION_CHANGED
 // event naming the union of the previous and the new flag keys, as required by
 // Appendix A of the OpenFeature specification.
+//
+// As in [NewInMemoryProvider], the map is copied shallowly: the provider takes
+// ownership of each flag's Variants and ContextEvaluator, which must not be
+// mutated once the flag has been handed over.
 //
 // The event is dropped rather than blocking the caller when nothing is draining
 // the event channel, which is the case while the provider is not registered

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -2,7 +2,10 @@ package memprovider
 
 import (
 	"math"
+	"slices"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
 )
@@ -356,4 +359,209 @@ func TestInMemoryProvider_Metadata(t *testing.T) {
 func TestInMemoryProvider_Track(t *testing.T) {
 	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{})
 	memoryProvider.Track(t.Context(), "example-event-name", openfeature.EvaluationContext{}, openfeature.TrackingEventDetails{})
+}
+
+func boolFlag(key, variant string) InMemoryFlag {
+	return InMemoryFlag{
+		Key:            key,
+		State:          Enabled,
+		DefaultVariant: variant,
+		Variants:       map[string]any{"true": true, "false": false},
+	}
+}
+
+// waitForEvent reads the next event off the provider's channel.
+func waitForEvent(t *testing.T, provider *InMemoryProvider) openfeature.Event {
+	t.Helper()
+
+	select {
+	case event := <-provider.EventChannel():
+		return event
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timeout - no event emitted")
+		return openfeature.Event{}
+	}
+}
+
+func TestInMemoryProvider_UpdateFlags(t *testing.T) {
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{
+		"flagA": boolFlag("flagA", "true"),
+	})
+
+	if got := memoryProvider.BooleanEvaluation(t.Context(), "flagA", false, nil); got.Value != true {
+		t.Errorf("expected flagA to resolve true before the update, got %v", got.Value)
+	}
+
+	memoryProvider.UpdateFlags(map[string]InMemoryFlag{
+		"flagA": boolFlag("flagA", "false"),
+		"flagB": boolFlag("flagB", "true"),
+	})
+
+	if got := memoryProvider.BooleanEvaluation(t.Context(), "flagA", true, nil); got.Value != false {
+		t.Errorf("expected flagA to resolve false after the update, got %v", got.Value)
+	}
+
+	if got := memoryProvider.BooleanEvaluation(t.Context(), "flagB", false, nil); got.Value != true {
+		t.Errorf("expected flagB to resolve true after the update, got %v", got.Value)
+	}
+}
+
+func TestInMemoryProvider_UpdateFlagsRemovesFlags(t *testing.T) {
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{
+		"flagA": boolFlag("flagA", "true"),
+	})
+
+	memoryProvider.UpdateFlags(map[string]InMemoryFlag{})
+
+	detail := memoryProvider.BooleanEvaluation(t.Context(), "flagA", false, nil)
+	if detail.Value != false {
+		t.Errorf("expected the default value for a removed flag, got %v", detail.Value)
+	}
+
+	if detail.ResolutionError.Error() == "" {
+		t.Error("expected a resolution error for a removed flag")
+	}
+
+	if detail.Reason != openfeature.ErrorReason {
+		t.Errorf("expected %s, got %s", openfeature.ErrorReason, detail.Reason)
+	}
+}
+
+func TestInMemoryProvider_UpdateFlagsEmitsConfigurationChanged(t *testing.T) {
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{
+		"removed": boolFlag("removed", "true"),
+		"kept":    boolFlag("kept", "true"),
+	})
+
+	memoryProvider.UpdateFlags(map[string]InMemoryFlag{
+		"kept":  boolFlag("kept", "false"),
+		"added": boolFlag("added", "true"),
+	})
+
+	event := waitForEvent(t, memoryProvider)
+
+	if event.EventType != openfeature.ProviderConfigChange {
+		t.Errorf("expected %s, got %s", openfeature.ProviderConfigChange, event.EventType)
+	}
+
+	if event.ProviderName != "InMemoryProvider" {
+		t.Errorf("expected provider name InMemoryProvider, got %s", event.ProviderName)
+	}
+
+	// The union of all previous and all new flag keys, per Appendix A.
+	want := []string{"added", "kept", "removed"}
+	if !slices.Equal(event.FlagChanges, want) {
+		t.Errorf("expected flag changes %v, got %v", want, event.FlagChanges)
+	}
+}
+
+func TestInMemoryProvider_ConstructorCopiesFlags(t *testing.T) {
+	flags := map[string]InMemoryFlag{
+		"flagA": boolFlag("flagA", "true"),
+	}
+
+	memoryProvider := NewInMemoryProvider(flags)
+	delete(flags, "flagA")
+	flags["flagB"] = boolFlag("flagB", "true")
+
+	if got := memoryProvider.BooleanEvaluation(t.Context(), "flagA", false, nil); got.Value != true {
+		t.Error("mutating the caller's map must not affect the provider")
+	}
+
+	if got := memoryProvider.BooleanEvaluation(t.Context(), "flagB", false, nil); got.Value != false {
+		t.Error("mutating the caller's map must not affect the provider")
+	}
+}
+
+func TestInMemoryProvider_UpdateFlagsDoesNotBlockWithoutSubscriber(t *testing.T) {
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Nothing drains the channel here, so this only returns if the send is
+		// non-blocking once the buffer fills.
+		for range eventChannelBuffer * 3 {
+			memoryProvider.UpdateFlags(map[string]InMemoryFlag{"flagA": boolFlag("flagA", "true")})
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("UpdateFlags blocked with no subscriber draining the event channel")
+	}
+}
+
+func TestInMemoryProvider_ConcurrentUpdateAndEvaluation(t *testing.T) {
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{
+		"flagA": boolFlag("flagA", "true"),
+	})
+
+	// Drain events so the writer is never throttled by a full buffer.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-memoryProvider.EventChannel():
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			for range 100 {
+				memoryProvider.UpdateFlags(map[string]InMemoryFlag{"flagA": boolFlag("flagA", "false")})
+			}
+		})
+		wg.Go(func() {
+			for range 100 {
+				memoryProvider.BooleanEvaluation(t.Context(), "flagA", false, nil)
+			}
+		})
+		wg.Go(func() {
+			for range 100 {
+				memoryProvider.Track(t.Context(), "event", openfeature.EvaluationContext{}, openfeature.TrackingEventDetails{})
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// TestInMemoryProvider_ConfigurationChangedReachesHandler covers the path the
+// issue is about: an update on a registered provider reaching an API handler.
+func TestInMemoryProvider_ConfigurationChangedReachesHandler(t *testing.T) {
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{
+		"flagA": boolFlag("flagA", "true"),
+	})
+
+	if err := openfeature.SetProviderAndWait(memoryProvider); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(openfeature.Shutdown)
+
+	received := make(chan openfeature.EventDetails, 1)
+	callback := func(details openfeature.EventDetails) {
+		received <- details
+	}
+	openfeature.AddHandler(openfeature.ProviderConfigChange, &callback)
+	t.Cleanup(func() {
+		openfeature.RemoveHandler(openfeature.ProviderConfigChange, &callback)
+	})
+
+	memoryProvider.UpdateFlags(map[string]InMemoryFlag{"flagB": boolFlag("flagB", "true")})
+
+	select {
+	case details := <-received:
+		want := []string{"flagA", "flagB"}
+		if !slices.Equal(details.FlagChanges, want) {
+			t.Errorf("expected flag changes %v, got %v", want, details.FlagChanges)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout - PROVIDER_CONFIGURATION_CHANGED did not reach the handler")
+	}
 }

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -473,6 +473,26 @@ func TestInMemoryProvider_ConstructorCopiesFlags(t *testing.T) {
 	}
 }
 
+func TestInMemoryProvider_BuffersEventsUntilSubscriberAttaches(t *testing.T) {
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{})
+
+	// Nothing is draining the channel yet, as is the case before the provider
+	// is registered with an API.
+	memoryProvider.UpdateFlags(map[string]InMemoryFlag{"flagA": boolFlag("flagA", "true")})
+	memoryProvider.UpdateFlags(map[string]InMemoryFlag{"flagB": boolFlag("flagB", "true")})
+
+	// A listener attaching later still sees both, in the order they were made.
+	first := waitForEvent(t, memoryProvider)
+	if want := []string{"flagA"}; !slices.Equal(first.FlagChanges, want) {
+		t.Errorf("expected flag changes %v, got %v", want, first.FlagChanges)
+	}
+
+	second := waitForEvent(t, memoryProvider)
+	if want := []string{"flagA", "flagB"}; !slices.Equal(second.FlagChanges, want) {
+		t.Errorf("expected flag changes %v, got %v", want, second.FlagChanges)
+	}
+}
+
 func TestInMemoryProvider_UpdateFlagsDoesNotBlockWithoutSubscriber(t *testing.T) {
 	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{})
 

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -1,6 +1,7 @@
 package memprovider
 
 import (
+	"context"
 	"math"
 	"slices"
 	"sync"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/isolated"
 )
 
 func TestInMemoryProvider_boolean(t *testing.T) {
@@ -519,13 +521,11 @@ func TestInMemoryProvider_ConcurrentUpdateAndEvaluation(t *testing.T) {
 	})
 
 	// Drain events so the writer is never throttled by a full buffer.
-	stop := make(chan struct{})
-	defer close(stop)
 	go func() {
 		for {
 			select {
 			case <-memoryProvider.EventChannel():
-			case <-stop:
+			case <-t.Context().Done():
 				return
 			}
 		}
@@ -559,18 +559,22 @@ func TestInMemoryProvider_ConfigurationChangedReachesHandler(t *testing.T) {
 		"flagA": boolFlag("flagA", "true"),
 	})
 
-	if err := openfeature.SetProviderAndWait(memoryProvider); err != nil {
+	api := isolated.NewAPI()
+	t.Cleanup(func() {
+		_ = api.Shutdown(context.Background()) //nolint:usetesting
+	})
+
+	if err := api.SetProviderAndWait(t.Context(), memoryProvider); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(openfeature.Shutdown)
 
 	received := make(chan openfeature.EventDetails, 1)
 	callback := func(details openfeature.EventDetails) {
 		received <- details
 	}
-	openfeature.AddHandler(openfeature.ProviderConfigChange, &callback)
+	api.AddHandler(openfeature.ProviderConfigChange, &callback)
 	t.Cleanup(func() {
-		openfeature.RemoveHandler(openfeature.ProviderConfigChange, &callback)
+		api.RemoveHandler(openfeature.ProviderConfigChange, &callback)
 	})
 
 	memoryProvider.UpdateFlags(map[string]InMemoryFlag{"flagB": boolFlag("flagB", "true")})


### PR DESCRIPTION
Fixes #530

Appendix A requires the in-memory provider to support updating its flag set and emit `PROVIDER_CONFIGURATION_CHANGED` with the union of the previous and new flag keys. Go had neither, unlike JS (`putConfiguration()`) and Java (`updateFlag()`), which blocks the conformance suite from covering configuration-change scenarios.

Adds `UpdateFlags` and `EventChannel`, guards the flag set and tracking events with a mutex, and copies the flag map on construction and update so readers hold an immutable snapshot.

## ⚠️ Breaking change

`NewInMemoryProvider` now returns `*InMemoryProvider`, with all methods on pointer receivers. It has to be a pointer: `providerReference.equals` falls back to `reflect.DeepEqual` for non-pointer providers, so two providers with equal flag sets compared as the same provider — and that `DeepEqual` walks the flag map unsynchronised while `UpdateFlags` mutates it.

Migration affects only code that names the type explicitly:

```diff
-var p memprovider.InMemoryProvider = memprovider.NewInMemoryProvider(flags)
+var p *memprovider.InMemoryProvider = memprovider.NewInMemoryProvider(flags)
```

`p := memprovider.NewInMemoryProvider(flags)` is unaffected. Nothing in this repo needed changing.

## Notes

- The event is dropped rather than blocking when nothing drains the channel (provider not registered); a blocking send would deadlock the caller.
- The channel is never closed — the SDK's forwarding goroutine exits on its own shutdown signal, and closing would panic a later `UpdateFlags`.
- Construction no longer aliases the caller's map. That aliasing was unsynchronised, so relying on it was never safe.
- `StateHandler` is deliberately left for a separate change.

Tests cover the flag swap, removal, the sorted union, event type and provider name, constructor copy semantics, non-blocking emission, concurrent update/evaluate/track under `-race`, and one end-to-end case asserting a registered handler fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)