### PR TITLE
fix: populate EvaluationDetails on NOT_READY/FATAL short-circuit

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -692,7 +692,7 @@ func (c *Client) evaluate(
 		if c.State() == NotReadyState {
 			evalDetails.Reason = ErrorReason
 			evalDetails.ErrorCode = ProviderNotReadyCode
-			evalDetails.ErrorMessage = ProviderNotReadyError.Error()
+			evalDetails.ErrorMessage = ProviderNotReadyError.message
 			c.errorHooks(ctx, hookCtx, hooks, ProviderNotReadyError, options)
 			return evalDetails, ProviderNotReadyError
 		}
@@ -701,7 +701,7 @@ func (c *Client) evaluate(
 		if c.State() == FatalState {
 			evalDetails.Reason = ErrorReason
 			evalDetails.ErrorCode = ProviderFatalCode
-			evalDetails.ErrorMessage = ProviderFatalError.Error()
+			evalDetails.ErrorMessage = ProviderFatalError.message
 			c.errorHooks(ctx, hookCtx, hooks, ProviderFatalError, options)
 			return evalDetails, ProviderFatalError
 		}

--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -690,12 +690,18 @@ func (c *Client) evaluate(
 	if _, ok := provider.(NoopProvider); !ok {
 		// short circuit if provider is in NOT READY state
 		if c.State() == NotReadyState {
+			evalDetails.Reason = ErrorReason
+			evalDetails.ErrorCode = ProviderNotReadyCode
+			evalDetails.ErrorMessage = ProviderNotReadyError.Error()
 			c.errorHooks(ctx, hookCtx, hooks, ProviderNotReadyError, options)
 			return evalDetails, ProviderNotReadyError
 		}
 
 		// short circuit if provider is in FATAL state
 		if c.State() == FatalState {
+			evalDetails.Reason = ErrorReason
+			evalDetails.ErrorCode = ProviderFatalCode
+			evalDetails.ErrorMessage = ProviderFatalError.Error()
 			c.errorHooks(ctx, hookCtx, hooks, ProviderFatalError, options)
 			return evalDetails, ProviderFatalError
 		}

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -1462,7 +1462,10 @@ func TestEvaluationDetails_NotReady(t *testing.T) {
 
 // BooleanValueDetails MUST populate Reason, ErrorCode, and ErrorMessage when provider is FATAL.
 func TestEvaluationDetails_Fatal(t *testing.T) {
-	t.Cleanup(resetSingleton)
+	api := newAPI()
+	t.Cleanup(func() {
+		_ = api.Shutdown(context.Background()) //nolint:usetesting
+	})
 
 	fatalProvider := struct {
 		FeatureProvider
@@ -1478,12 +1481,12 @@ func TestEvaluationDetails_Fatal(t *testing.T) {
 		&ProviderEventing{},
 	}
 
-	err := SetNamedProviderAndWait(t.Name(), fatalProvider)
+	err := api.SetProviderAndWait(t.Context(), fatalProvider, WithDomain(t.Name()))
 	if err == nil {
 		t.Errorf("provider registration was expected to fail but succeeded unexpectedly")
 	}
 
-	client := NewClient(t.Name())
+	client := api.NewClient(WithDomain(t.Name()))
 
 	if client.State() != FatalState {
 		t.Fatalf("expected client to report FATAL state")

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -1403,6 +1403,116 @@ func TestRequirement_1_7_7(t *testing.T) {
 	}
 }
 
+// BooleanValueDetails MUST populate Reason, ErrorCode, and ErrorMessage when provider is NOT_READY.
+func TestEvaluationDetails_NotReady(t *testing.T) {
+	t.Cleanup(func() {
+		resetSingleton()
+	})
+
+	// Use a channel that blocks until test cleanup to keep provider in NOT_READY state
+	blockChan := make(chan struct{})
+	t.Cleanup(func() {
+		close(blockChan)
+	})
+
+	notReadyProvider := struct {
+		FeatureProvider
+		StateHandler
+		EventHandler
+	}{
+		NoopProvider{},
+		&stateHandlerForTests{
+			initF: func(e EvaluationContext) error {
+				<-blockChan
+				return nil
+			},
+		},
+		&ProviderEventing{},
+	}
+
+	_ = SetProvider(notReadyProvider)
+
+	client := NewClient("notReadyDetailsClient")
+
+	if client.State() != NotReadyState {
+		t.Fatalf("expected client to report NOT READY state")
+	}
+
+	defaultVal := true
+	details, err := client.BooleanValueDetails(t.Context(), "a-flag", defaultVal, EvaluationContext{})
+	if err == nil {
+		t.Fatalf("expected client to report an error")
+	}
+
+	if details.Value != defaultVal {
+		t.Fatalf("expected default value %t, got %t", defaultVal, details.Value)
+	}
+
+	if details.Reason != ErrorReason {
+		t.Errorf("expected Reason %q, got %q", ErrorReason, details.Reason)
+	}
+
+	if details.ErrorCode != ProviderNotReadyCode {
+		t.Errorf("expected ErrorCode %q, got %q", ProviderNotReadyCode, details.ErrorCode)
+	}
+
+	if details.ErrorMessage == "" {
+		t.Error("expected non-empty ErrorMessage")
+	}
+}
+
+// BooleanValueDetails MUST populate Reason, ErrorCode, and ErrorMessage when provider is FATAL.
+func TestEvaluationDetails_Fatal(t *testing.T) {
+	t.Cleanup(resetSingleton)
+
+	fatalProvider := struct {
+		FeatureProvider
+		StateHandler
+		EventHandler
+	}{
+		NoopProvider{},
+		&stateHandlerForTests{
+			initF: func(e EvaluationContext) error {
+				return &ProviderInitError{ErrorCode: ProviderFatalCode}
+			},
+		},
+		&ProviderEventing{},
+	}
+
+	err := SetNamedProviderAndWait(t.Name(), fatalProvider)
+	if err == nil {
+		t.Errorf("provider registration was expected to fail but succeeded unexpectedly")
+	}
+
+	client := NewClient(t.Name())
+
+	if client.State() != FatalState {
+		t.Fatalf("expected client to report FATAL state")
+	}
+
+	defaultVal := true
+	details, err := client.BooleanValueDetails(t.Context(), "a-flag", defaultVal, EvaluationContext{})
+	if err == nil {
+		t.Fatalf("expected client to report an error")
+	}
+
+	if details.Value != defaultVal {
+		t.Fatalf("expected default value %t, got %t", defaultVal, details.Value)
+	}
+
+	if details.Reason != ErrorReason {
+		t.Errorf("expected Reason %q, got %q", ErrorReason, details.Reason)
+	}
+
+	if details.ErrorCode != ProviderFatalCode {
+		t.Errorf("expected ErrorCode %q, got %q", ProviderFatalCode, details.ErrorCode)
+	}
+
+	if details.ErrorMessage == "" {
+		t.Error("expected non-empty ErrorMessage")
+	}
+}
+
 // Implementations SHOULD propagate the error code returned from any provider lifecycle methods.
 func TestRequirement_1_7_8(t *testing.T) {
 	t.Skip("Test not yet implemented")

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -1455,8 +1455,8 @@ func TestEvaluationDetails_NotReady(t *testing.T) {
 		t.Errorf("expected ErrorCode %q, got %q", ProviderNotReadyCode, details.ErrorCode)
 	}
 
-	if details.ErrorMessage == "" {
-		t.Error("expected non-empty ErrorMessage")
+	if details.ErrorMessage != ProviderNotReadyError.message {
+		t.Errorf("expected ErrorMessage %q, got %q", ProviderNotReadyError.message, details.ErrorMessage)
 	}
 }
 
@@ -1510,8 +1510,8 @@ func TestEvaluationDetails_Fatal(t *testing.T) {
 		t.Errorf("expected ErrorCode %q, got %q", ProviderFatalCode, details.ErrorCode)
 	}
 
-	if details.ErrorMessage == "" {
-		t.Error("expected non-empty ErrorMessage")
+	if details.ErrorMessage != ProviderFatalError.message {
+		t.Errorf("expected ErrorMessage %q, got %q", ProviderFatalError.message, details.ErrorMessage)
 	}
 }
 

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -1405,14 +1405,9 @@ func TestRequirement_1_7_7(t *testing.T) {
 
 // BooleanValueDetails MUST populate Reason, ErrorCode, and ErrorMessage when provider is NOT_READY.
 func TestEvaluationDetails_NotReady(t *testing.T) {
+	api := newAPI()
 	t.Cleanup(func() {
-		resetSingleton()
-	})
-
-	// Use a channel that blocks until test cleanup to keep provider in NOT_READY state
-	blockChan := make(chan struct{})
-	t.Cleanup(func() {
-		close(blockChan)
+		_ = api.Shutdown(context.Background()) //nolint:usetesting
 	})
 
 	notReadyProvider := struct {
@@ -1423,16 +1418,20 @@ func TestEvaluationDetails_NotReady(t *testing.T) {
 		NoopProvider{},
 		&stateHandlerForTests{
 			initF: func(e EvaluationContext) error {
-				<-blockChan
+				// Block until test cleanup to keep provider in NOT_READY state
+				<-t.Context().Done()
 				return nil
 			},
 		},
 		&ProviderEventing{},
 	}
 
-	_ = SetProvider(notReadyProvider)
+	err := api.SetProvider(t.Context(), notReadyProvider)
+	if err != nil {
+		t.Fatalf("failed to set up provider: %v", err)
+	}
 
-	client := NewClient("notReadyDetailsClient")
+	client := api.NewClient()
 
 	if client.State() != NotReadyState {
 		t.Fatalf("expected client to report NOT READY state")


### PR DESCRIPTION
## Motivation & Context

Fixes #540

When the provider state is `NOT_READY` or `FATAL`, the `evaluate()` function in `client.go` short-circuits and returns an `EvaluationDetails` struct without populating `Reason`, `ErrorCode`, or `ErrorMessage`. The error information is only available in the separate `error` return value. Consumers using `BooleanValueDetails` (and similar typed detail methods) receive an empty `ResolutionDetail`, which is inconsistent with the spec and with how other error paths in the same function behave.

## Change

Set `Reason`, `ErrorCode`, and `ErrorMessage` on the `evalDetails` struct before returning in both the `NotReadyState` and `FatalState` short-circuit blocks.

## Testing

Added two tests (`TestEvaluationDetails_NotReady`, `TestEvaluationDetails_Fatal`) that call `BooleanValueDetails` when the provider is in NOT_READY or FATAL state and assert that `Reason`, `ErrorCode`, and `ErrorMessage` are populated on the returned details struct. Full test suite passes.