### PR TITLE
fix: coerce int types to float64 in memprovider float evaluation

### DIFF
--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -157,7 +157,7 @@ func (i InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.Provide
 // helpers
 
 // genericResolve is a helper to extract type verified evaluation and fill openfeature.ProviderResolutionDetail.
-// It coerces smaller numeric types to their canonical forms (int* -> int64, float32 -> float64)
+// It coerces smaller numeric types to their canonical forms (int* -> int64, int* | float32 -> float64)
 // to provide a more forgiving API for test flag configuration.
 //
 // Note: Only signed integer types are supported for conversion. Unsigned integer types

--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -187,6 +187,16 @@ func genericResolve[T comparable](value any, defaultValue T, detail *openfeature
 		switch v := value.(type) {
 		case float32:
 			return any(float64(v)).(T)
+		case int8:
+			return any(float64(v)).(T)
+		case int16:
+			return any(float64(v)).(T)
+		case int32:
+			return any(float64(v)).(T)
+		case int:
+			return any(float64(v)).(T)
+		case int64:
+			return any(float64(v)).(T)
 		}
 	}
 

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -100,6 +100,78 @@ func TestInMemoryProvider_Float(t *testing.T) {
 	})
 }
 
+func TestInMemoryProvider_FloatIntCoercion(t *testing.T) {
+	// Signed integer variants on a float flag should be coerced to float64,
+	// mirroring how the int64 branch of genericResolve accepts int types.
+	tests := []struct {
+		name     string
+		variant  any
+		expected float64
+	}{
+		{
+			name:     "plain int coerced to float64",
+			variant:  42,
+			expected: 42,
+		},
+		{
+			name:     "int8 coerced to float64",
+			variant:  int8(8),
+			expected: 8,
+		},
+		{
+			name:     "int16 coerced to float64",
+			variant:  int16(16),
+			expected: 16,
+		},
+		{
+			name:     "int32 coerced to float64",
+			variant:  int32(32),
+			expected: 32,
+		},
+		{
+			name:     "int64 coerced to float64",
+			variant:  int64(64),
+			expected: 64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{
+				"floatFlag": {
+					State:          Enabled,
+					DefaultVariant: "value",
+					Variants:       map[string]any{"value": tt.variant},
+				},
+			})
+
+			evaluation := memoryProvider.FloatEvaluation(t.Context(), "floatFlag", 0, nil)
+
+			if evaluation.Value != tt.expected {
+				t.Errorf("expected %f, got %f", tt.expected, evaluation.Value)
+			}
+		})
+	}
+}
+
+func TestInMemoryProvider_FloatUnsignedIntTypeMismatch(t *testing.T) {
+	// genericResolve intentionally does not coerce unsigned integer types;
+	// keep that limitation visible as a TYPE_MISMATCH.
+	memoryProvider := NewInMemoryProvider(map[string]InMemoryFlag{
+		"floatFlag": {
+			State:          Enabled,
+			DefaultVariant: "value",
+			Variants:       map[string]any{"value": uint64(7)},
+		},
+	})
+
+	evaluation := memoryProvider.FloatEvaluation(t.Context(), "floatFlag", 0, nil)
+
+	if evaluation.ResolutionDetail().ErrorCode != openfeature.TypeMismatchCode {
+		t.Errorf("expected TYPE_MISMATCH, got %q", evaluation.ResolutionDetail().ErrorCode)
+	}
+}
+
 func TestInMemoryProvider_Int(t *testing.T) {
 	// Test that both int and int64 variants work correctly.
 	// The provider coerces int to int64 internally to match the API contract.


### PR DESCRIPTION
The float64 branch in genericResolve only converted float32, even though
its comment says it handles int types as well. In practice a float flag
configured with a plain int variant, e.g. `Variants: map[string]any{"on": 1}`,
came back as TYPE_MISMATCH through FloatEvaluation, while the int64 branch
accepts those same int types fine.

Added the signed int cases (int, int8, int16, int32, int64) to the float64
conversion, mirroring the int64 branch. Unsigned types still fall through to
a type mismatch, which is what the doc comment on the helper states.

Tests cover each coerced type plus one case locking in the unsigned behavior.

Fixes #564
