### PR TITLE
fix: return default value from ObjectValueDetails on abnormal execution

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -766,7 +766,7 @@ func (c *Client) evaluate(
 		c.errorHooks(ctx, hookCtx, hooks, err, options)
 		evalDetails.Reason = ErrorReason
 		evalDetails.ErrorCode = GeneralCode
-		evalDetails.ErrorMessage = err.Error()
+		evalDetails.ErrorMessage = "error executing after hooks"
 		return evalDetails, err
 	}
 

--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -764,6 +764,9 @@ func (c *Client) evaluate(
 	if err := c.afterHooks(ctx, hookCtx, hooks, evalDetails, options); err != nil {
 		err = fmt.Errorf("after hook: %w", err)
 		c.errorHooks(ctx, hookCtx, hooks, err, options)
+		evalDetails.Reason = ErrorReason
+		evalDetails.ErrorCode = GeneralCode
+		evalDetails.ErrorMessage = err.Error()
 		return evalDetails, err
 	}
 

--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -539,7 +539,15 @@ func (c *Client) ObjectValueDetails(ctx context.Context, flag string, defaultVal
 		option(evalOptions)
 	}
 
-	return c.evaluate(ctx, flag, Object, defaultValue, evalCtx, *evalOptions)
+	evalDetails, err := c.evaluate(ctx, flag, Object, defaultValue, evalCtx, *evalOptions)
+	if err != nil {
+		return InterfaceEvaluationDetails{
+			Value:             defaultValue,
+			EvaluationDetails: evalDetails.EvaluationDetails,
+		}, err
+	}
+
+	return evalDetails, nil
 }
 
 // Boolean performs a flag evaluation that returns a boolean. Any error

--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -764,9 +764,6 @@ func (c *Client) evaluate(
 	if err := c.afterHooks(ctx, hookCtx, hooks, evalDetails, options); err != nil {
 		err = fmt.Errorf("after hook: %w", err)
 		c.errorHooks(ctx, hookCtx, hooks, err, options)
-		evalDetails.Reason = ErrorReason
-		evalDetails.ErrorCode = GeneralCode
-		evalDetails.ErrorMessage = "error executing after hooks"
 		return evalDetails, err
 	}
 

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -654,6 +654,41 @@ func TestRequirement_1_4_9(t *testing.T) {
 			t.Errorf("expected default value from ObjectValueDetails, got %v", value)
 		}
 	})
+
+	// A hook error is abnormal execution too. The existing subtests above drive
+	// abnormal execution through a resolution error, which returns before the
+	// resolved value is assigned; a failing after hook returns after it.
+	t.Run("Object with erroring after hook", func(t *testing.T) {
+		t.Cleanup(resetSingleton)
+
+		mocks := hydratedMocksForClientTests(t, 1)
+		client := newClient("test-client", mocks.providerBinding, mocks.clientHandlerAPI)
+
+		type obj struct {
+			foo string
+		}
+		defaultValue := obj{foo: "bar"}
+		resolvedValue := obj{foo: "resolved"}
+
+		mocks.providerAPI.EXPECT().ObjectEvaluation(t.Context(), flagKey, defaultValue, flatCtx).
+			Return(InterfaceResolutionDetail{Value: resolvedValue})
+
+		mockHook := NewMockHook(gomock.NewController(t))
+		mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any())
+		mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			After(mockHook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(errors.New("forced")))
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+
+		valueDetails, err := client.ObjectValueDetails(t.Context(), flagKey, defaultValue, evalCtx, WithHooks(mockHook))
+		if err == nil {
+			t.Error("expected ObjectValueDetails to return an error, got nil")
+		}
+
+		if valueDetails.Value.(obj) != defaultValue {
+			t.Errorf("expected default value from ObjectValueDetails, got %v", valueDetails.Value)
+		}
+	})
 }
 
 // TODO Requirement_1_4_10

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -688,6 +688,14 @@ func TestRequirement_1_4_9(t *testing.T) {
 		if valueDetails.Value.(obj) != defaultValue {
 			t.Errorf("expected default value from ObjectValueDetails, got %v", valueDetails.Value)
 		}
+
+		if valueDetails.Reason != ErrorReason {
+			t.Errorf("expected reason %s, got %s", ErrorReason, valueDetails.Reason)
+		}
+
+		if valueDetails.ErrorCode != GeneralCode {
+			t.Errorf("expected error code %s, got %s", GeneralCode, valueDetails.ErrorCode)
+		}
 	})
 }
 

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -695,6 +696,15 @@ func TestRequirement_1_4_9(t *testing.T) {
 
 		if valueDetails.ErrorCode != GeneralCode {
 			t.Errorf("expected error code %s, got %s", GeneralCode, valueDetails.ErrorCode)
+		}
+
+		if valueDetails.ErrorMessage != afterHookErrorMessage {
+			t.Errorf("expected error message %q, got %q", afterHookErrorMessage, valueDetails.ErrorMessage)
+		}
+
+		// the hook's own error text must not leak into the public details
+		if strings.Contains(valueDetails.ErrorMessage, "forced") {
+			t.Errorf("hook error text leaked into ErrorMessage: %q", valueDetails.ErrorMessage)
 		}
 	})
 }

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -688,23 +687,6 @@ func TestRequirement_1_4_9(t *testing.T) {
 
 		if valueDetails.Value.(obj) != defaultValue {
 			t.Errorf("expected default value from ObjectValueDetails, got %v", valueDetails.Value)
-		}
-
-		if valueDetails.Reason != ErrorReason {
-			t.Errorf("expected reason %s, got %s", ErrorReason, valueDetails.Reason)
-		}
-
-		if valueDetails.ErrorCode != GeneralCode {
-			t.Errorf("expected error code %s, got %s", GeneralCode, valueDetails.ErrorCode)
-		}
-
-		if valueDetails.ErrorMessage != afterHookErrorMessage {
-			t.Errorf("expected error message %q, got %q", afterHookErrorMessage, valueDetails.ErrorMessage)
-		}
-
-		// the hook's own error text must not leak into the public details
-		if strings.Contains(valueDetails.ErrorMessage, "forced") {
-			t.Errorf("hook error text leaked into ErrorMessage: %q", valueDetails.ErrorMessage)
 		}
 	})
 }


### PR DESCRIPTION
## This PR

- returns the default value from `ObjectValueDetails` when evaluation ends abnormally, instead of the value the provider resolved
- adds an `Object with erroring after hook` subtest to `TestRequirement_1_4_9` covering the hook-error path

`ObjectValueDetails` returned `c.evaluate(...)` directly, so on abnormal execution the caller received whatever the provider resolved. The five typed accessors don't behave this way — `BooleanValueDetails` and friends reset `Value` to the supplied default before returning the error.

This is reachable through a failing hook. With an after hook that errors:

```
object: value=map[from:provider]  err=after hook: after hook boom
bool  : value=false               err=after hook: after hook boom
```

Requirement 1.4.10 states that flag evaluation calls must always return the default value in the event of abnormal execution.

### Related Issues

Fixes #553

### Notes

- The method's existing doc comment already documents this behaviour ("defaultValue is returned if an error occurs"), so this makes the code honour a contract it already advertises.
- `ObjectValue` was already correct — it guards on the error and returns the default. Only the `...Details` variant was affected.
-  The reset happens on any error rather than only on the hook path, matching the typed accessors. The other error paths already return the default, so this is a no-op for them today — but only because `evalDetails.Value = resolution.Value` happens to sit below their return points. Guarding unconditionally keeps the accessor correct regardless of where that assignment moves.
- The existing `Object` subtest drives abnormal execution through a resolution error, which returns before the resolved value is assigned. A failing after hook returns after it, so that path was previously uncovered.

### How to test

```
go test -tags testtools -race -count=1 -v -run 'TestRequirement_1_4_9' ./openfeature/
```