### PR TITLE
fix: populate error fields on the UTF-8 and before hook returns

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -663,7 +663,11 @@ func (c *Client) evaluate(
 	}
 
 	if !utf8.Valid([]byte(flag)) {
-		return evalDetails, NewParseErrorResolutionError("flag key is not a UTF-8 encoded string")
+		err := NewParseErrorResolutionError("flag key is not a UTF-8 encoded string")
+		evalDetails.Reason = ErrorReason
+		evalDetails.ErrorCode = err.code
+		evalDetails.ErrorMessage = err.message
+		return evalDetails, err
 	}
 
 	// ensure that the same provider & hooks are used across this transaction to avoid unexpected behaviour
@@ -711,6 +715,9 @@ func (c *Client) evaluate(
 	hookCtx.evaluationContext = evalCtx
 	if err != nil {
 		err = fmt.Errorf("before hook: %w", err)
+		evalDetails.Reason = ErrorReason
+		evalDetails.ErrorCode = errorCodeOf(err)
+		evalDetails.ErrorMessage = err.Error()
 		c.errorHooks(ctx, hookCtx, hooks, err, options)
 		return evalDetails, err
 	}
@@ -826,6 +833,17 @@ func (c *Client) finallyHooks(ctx context.Context, hookCtx HookContext, hooks []
 
 // merges attributes from the given EvaluationContexts with the nth EvaluationContext taking precedence in case
 // of any conflicts with the (n+1)th EvaluationContext
+// errorCodeOf returns the ErrorCode carried by err, or GeneralCode when err is
+// not a ResolutionError. Hooks are free to return an arbitrary error, so the
+// code is only as specific as the error the hook chose to return.
+func errorCodeOf(err error) ErrorCode {
+	if resolutionErr, ok := errors.AsType[ResolutionError](err); ok {
+		return resolutionErr.code
+	}
+
+	return GeneralCode
+}
+
 func mergeContexts(evaluationContexts ...EvaluationContext) EvaluationContext {
 	if len(evaluationContexts) == 0 {
 		return EvaluationContext{}

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -477,6 +477,91 @@ func TestRequirement_1_4_8(t *testing.T) {
 	}
 }
 
+// An invalid UTF-8 flag key short-circuits evaluation before a provider is bound, so 1.4.7 and
+// 1.4.8 have to be satisfied on that return rather than by the provider's resolution.
+func TestEvaluationDetails_InvalidUTF8FlagKey(t *testing.T) {
+	t.Cleanup(resetSingleton)
+	mocks := hydratedMocksForClientTests(t, 0)
+	client := newClient("test-client", mocks.providerBinding, mocks.clientHandlerAPI)
+
+	defaultValue := true
+	res, err := client.evaluate(
+		t.Context(), string([]byte{0xff}), Boolean, defaultValue, EvaluationContext{}, EvaluationOptions{},
+	)
+	if err == nil {
+		t.Fatal("expected err, got nil")
+	}
+
+	if res.Value != defaultValue {
+		t.Errorf("expected default value %v, got %v", defaultValue, res.Value)
+	}
+	if res.Reason != ErrorReason {
+		t.Errorf("expected reason to be '%s', got '%s'", ErrorReason, res.Reason)
+	}
+	if res.ErrorCode != ParseErrorCode {
+		t.Errorf("expected error code to be '%s', got '%s'", ParseErrorCode, res.ErrorCode)
+	}
+	if res.ErrorMessage == "" {
+		t.Error("expected a non-empty error message")
+	}
+}
+
+// A before hook error is abnormal execution under 4.4.7, so 1.4.7 and 1.4.8 apply to the
+// evaluation details returned from that path. The code comes from the hook's own error when it
+// is a ResolutionError, and falls back to GENERAL otherwise.
+func TestEvaluationDetails_BeforeHookError(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		hookErr      error
+		expectedCode ErrorCode
+	}{
+		{
+			name:         "arbitrary error",
+			hookErr:      errors.New("forced"),
+			expectedCode: GeneralCode,
+		},
+		{
+			name:         "resolution error",
+			hookErr:      NewTargetingKeyMissingResolutionError("no targeting key"),
+			expectedCode: TargetingKeyMissingCode,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(resetSingleton)
+			ctrl := gomock.NewController(t)
+			mocks := hydratedMocksForClientTests(t, 1)
+			client := newClient("test-client", mocks.providerBinding, mocks.clientHandlerAPI)
+
+			mockHook := NewMockHook(ctrl)
+			mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, tt.hookErr)
+			mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+
+			defaultValue := true
+			res, err := client.evaluate(
+				t.Context(), "foo", Boolean, defaultValue, EvaluationContext{},
+				EvaluationOptions{hooks: []Hook{mockHook}},
+			)
+			if err == nil {
+				t.Fatal("expected err, got nil")
+			}
+
+			if res.Value != defaultValue {
+				t.Errorf("expected default value %v, got %v", defaultValue, res.Value)
+			}
+			if res.Reason != ErrorReason {
+				t.Errorf("expected reason to be '%s', got '%s'", ErrorReason, res.Reason)
+			}
+			if res.ErrorCode != tt.expectedCode {
+				t.Errorf("expected error code to be '%s', got '%s'", tt.expectedCode, res.ErrorCode)
+			}
+			if res.ErrorMessage == "" {
+				t.Error("expected a non-empty error message")
+			}
+		})
+	}
+}
+
 // Methods, functions, or operations on the client MUST NOT throw exceptions, or otherwise abnormally terminate.
 // Flag evaluation calls must always return the `default value` in the event of abnormal execution.
 // Exceptions include functions or methods for the purposes for configuration or setup.


### PR DESCRIPTION
## Motivation & Context

Fixes #567

Two of `Client.evaluate`'s early returns hand back an error with `Reason` and `ErrorCode` left empty on the evaluation details:

- an invalid UTF-8 flag key, which returns a parse error before the provider is bound;
- a before hook that fails.

The `NOT_READY` and `FATAL` short-circuits directly above already populate both, so a caller reading `BooleanValueDetails` (or any typed detail method) rather than the returned `error` gets nothing on these two paths. Per [1.4.7](https://openfeature.dev/specification/sections/flag-evaluation#requirement-147) the error code field MUST be populated in cases of abnormal execution, and [1.4.8](https://openfeature.dev/specification/sections/flag-evaluation#requirement-148) says the reason SHOULD indicate an error. A before hook error is abnormal execution under [4.4.7](https://openfeature.dev/specification/sections/hooks#requirement-447).

This is the same defect class as #540, fixed in #541.

## Change

Set `Reason`, `ErrorCode` and `ErrorMessage` on `evalDetails` before returning from both paths.

The UTF-8 path uses `PARSE_ERROR`, taken from the `ResolutionError` it already constructs. For the before hook path the code comes from the hook's own error when that error is a `ResolutionError`, and falls back to `GENERAL` otherwise — a hook may return an arbitrary error, and the Java and JS SDKs both preserve an OpenFeature error's own code rather than flattening every hook failure to `GENERAL`. That is what the small `errorCodeOf` helper does; happy to reduce it to a plain `GeneralCode` if you would rather not read the hook's error.

Deliberately out of scope, both called out on the issue:

- the after hook path, which has the same symptom — whether an after hook error counts as abnormal execution is still being settled in #566;
- the UTF-8 return not running the error hooks, which looks like a separate defect on the same line.

## Testing

Two new tests in `client_test.go`:

- `TestEvaluationDetails_InvalidUTF8FlagKey` — asserts the default value comes back with `ERROR`, `PARSE_ERROR` and a non-empty message, and that no provider binding happens.
- `TestEvaluationDetails_BeforeHookError` — two subtests, one with an arbitrary error expecting `GENERAL` and one with a `ResolutionError` expecting `TARGETING_KEY_MISSING`, both asserting the reason, code, message and default value, with the error and finally hooks still running.

All three fail on `main` with empty `Reason` and `ErrorCode` and pass with the change. `make test` and `make lint` are clean.