### PR TITLE
fix: merge before hook evaluation contexts instead of replacing them

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -781,7 +781,10 @@ func (c *Client) beforeHooks(
 	for _, hook := range hooks {
 		resultEvalCtx, err := hook.Before(ctx, hookCtx, options.hookHints)
 		if resultEvalCtx != nil {
-			hookCtx.evaluationContext = *resultEvalCtx
+			// Merge rather than replace, so a hook's contribution is visible to every
+			// subsequent hook instead of being overwritten by it. The newest result takes
+			// precedence over what earlier hooks contributed.
+			hookCtx.evaluationContext = mergeContexts(*resultEvalCtx, hookCtx.evaluationContext)
 		}
 		if err != nil {
 			return mergeContexts(hookCtx.evaluationContext, evalCtx), err

--- a/openfeature/hooks_test.go
+++ b/openfeature/hooks_test.go
@@ -235,9 +235,10 @@ func TestRequirement_4_3_3(t *testing.T) {
 		TargetingKey: "mockHook1",
 	})
 
-	// assert that the evaluation context returned by the first hook is passed into the second hook
+	// assert that the evaluation context returned by the first hook is merged into the context
+	// passed to the second hook, rather than replacing it
 	hook2Ctx := hook1Ctx
-	hook2Ctx.evaluationContext = *hook1EvalCtxResult
+	hook2Ctx.evaluationContext = mergeContexts(*hook1EvalCtxResult, evalCtx)
 	mockHook2.EXPECT().Before(gomock.Any(), hook2Ctx, gomock.Any())
 
 	mockHook1.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -252,6 +253,59 @@ func TestRequirement_4_3_3(t *testing.T) {
 }
 
 // When `before` hooks have finished executing, any resulting `evaluation context` MUST be merged with the existing
+
+// A before hook's evaluation context is merged into the accumulated one rather than replacing it,
+// so each hook observes every prior hook's contribution and the provider receives the union.
+func TestBeforeHooksAccumulateEvaluationContext(t *testing.T) {
+	t.Cleanup(resetSingleton)
+	ctrl := gomock.NewController(t)
+
+	mockProvider := NewMockFeatureProvider(ctrl)
+	mockProvider.EXPECT().Metadata().AnyTimes()
+	mockProvider.EXPECT().Hooks().AnyTimes()
+
+	if err := SetNamedProviderAndWait(t.Name(), mockProvider); err != nil {
+		t.Fatalf("error setting up provider %v", err)
+	}
+
+	flagKey := "foo"
+	defaultValue := "bar"
+
+	mockHookA := NewMockHook(ctrl)
+	mockHookB := NewMockHook(ctrl)
+
+	mockHookA.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&EvaluationContext{attributes: map[string]any{"from-hook-a": "a"}}, nil)
+
+	var seenByHookB map[string]any
+	mockHookB.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, hookCtx HookContext, _ HookHints) (*EvaluationContext, error) {
+			seenByHookB = hookCtx.EvaluationContext().Attributes()
+			return &EvaluationContext{attributes: map[string]any{"from-hook-b": "b"}}, nil
+		})
+
+	mockProvider.EXPECT().StringEvaluation(gomock.Any(), flagKey, defaultValue, map[string]any{
+		"from-hook-a": "a",
+		"from-hook-b": "b",
+	})
+
+	for _, hook := range []*MockHook{mockHookA, mockHookB} {
+		hook.EXPECT().After(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		hook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	}
+
+	_, err := NewClient(t.Name()).StringValueDetails(
+		t.Context(), flagKey, defaultValue, EvaluationContext{}, WithHooks(mockHookA, mockHookB),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if _, ok := seenByHookB["from-hook-a"]; !ok {
+		t.Errorf("hook B did not see hook A's contribution, got %v", seenByHookB)
+	}
+}
+
 // `evaluation context` in the following order:
 // before-hook (highest precedence), invocation, client, api (lowest precedence).
 func TestRequirement_4_3_4(t *testing.T) {

--- a/openfeature/hooks_test.go
+++ b/openfeature/hooks_test.go
@@ -274,14 +274,16 @@ func TestRequirement_4_3_3(t *testing.T) {
 // A before hook's evaluation context is merged into the accumulated one rather than replacing it,
 // so each hook observes every prior hook's contribution and the provider receives the union.
 func TestBeforeHooksAccumulateEvaluationContext(t *testing.T) {
-	t.Cleanup(resetSingleton)
+	api := newAPI()
+	t.Cleanup(func() { _ = api.Shutdown(context.Background()) }) //nolint:usetesting
+
 	ctrl := gomock.NewController(t)
 
 	mockProvider := NewMockFeatureProvider(ctrl)
 	mockProvider.EXPECT().Metadata().AnyTimes()
 	mockProvider.EXPECT().Hooks().AnyTimes()
 
-	if err := SetNamedProviderAndWait(t.Name(), mockProvider); err != nil {
+	if err := api.SetProviderAndWait(t.Context(), mockProvider, WithDomain(t.Name())); err != nil {
 		t.Fatalf("error setting up provider %v", err)
 	}
 
@@ -311,7 +313,7 @@ func TestBeforeHooksAccumulateEvaluationContext(t *testing.T) {
 		hook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	}
 
-	_, err := NewClient(t.Name()).StringValueDetails(
+	_, err := api.NewClient(WithDomain(t.Name())).StringValueDetails(
 		t.Context(), flagKey, defaultValue, EvaluationContext{}, WithHooks(mockHookA, mockHookB),
 	)
 	if err != nil {


### PR DESCRIPTION
## Motivation & Context

Fixes #549

In `Client.beforeHooks`, each hook's returned evaluation context wholly replaces the accumulated one:

```go
if resultEvalCtx != nil {
    hookCtx.evaluationContext = *resultEvalCtx
}
```

So with two hooks each contributing an attribute, everything the earlier hook added is dropped, and the later hook never sees it either. The provider ends up with only the last hook's contribution.

That misses [4.3.3](https://openfeature.dev/specification/sections/hooks#requirement-433) — a context returned from a before hook MUST be passed to subsequent before hooks — since what gets passed on is no longer the accumulation of what came before.

The other SDKs all accumulate: JS `Object.assign(accumulatedContext, hookResult)`, Java's `LayeredEvaluationContext` appends rather than replaces, Python reduces with `merge`. This repo's own `multi` package already does it correctly in `hookIsolator.beforeHooks`, so the two hook engines here currently disagree.

## Change

Merge the hook's result into the accumulated context instead of overwriting it. `mergeContexts` gives precedence to its first argument, so passing the hook result first keeps the newest contribution winning while retaining everything earlier hooks added — the same precedence as the JS `Object.assign`.

The existing merge with the invocation context on the way out is unchanged, so before-hook values still outrank invocation, client and API context.

## Testing

- New `TestBeforeHooksAccumulateEvaluationContext`: two hooks each contribute one attribute; asserts the second hook observes the first one's contribution and that the provider receives both. On `main` the provider sees only `map[from-hook-b:b]`.
- `TestRequirement_4_3_3` asserted the old replace behaviour — that the second hook receives exactly the first hook's returned context, with the invocation context's attributes dropped. Updated to expect the merged context, which is what the requirement it covers actually calls for. Its provider-level assertion is unchanged and still passes.

`make test` and `make lint` are clean.
