### PR TITLE
fix: report NOT_READY for a domain whose provider is initializing

### DIFF
--- a/openfeature/event_executor.go
+++ b/openfeature/event_executor.go
@@ -202,6 +202,11 @@ func (e *eventExecutor) registerDefaultProvider(provider FeatureProvider) {
 	oldProvider := e.defaultProviderReference
 	e.defaultProviderReference = newProvider
 
+	// A registered provider is NOT_READY until its initialization emits an event. Seeding the
+	// state here keeps the window between registration and that event from reporting the
+	// previous provider's status.
+	e.states.Store(defaultDomain, NotReadyState)
+
 	e.startListeningAndShutdownOld(newProvider, oldProvider)
 }
 
@@ -213,6 +218,10 @@ func (e *eventExecutor) registerNamedEventingProvider(associatedClient string, p
 
 	oldProvider := e.namedProviderReference[associatedClient]
 	e.namedProviderReference[associatedClient] = newProvider
+
+	// Seed NOT_READY so the domain does not fall back to the default provider's state while its
+	// own provider is still initializing. triggerEvent overwrites this once init completes.
+	e.states.Store(associatedClient, NotReadyState)
 
 	e.startListeningAndShutdownOld(newProvider, oldProvider)
 }

--- a/openfeature/isolated_api_test.go
+++ b/openfeature/isolated_api_test.go
@@ -392,3 +392,43 @@ func TestIsolatedAPI_ShutdownWithContextStopsEventExecutor(t *testing.T) {
 		t.Fatalf("ShutdownWithContext on isolated instance: %v", err)
 	}
 }
+
+// A domain whose own provider is still initializing MUST report NOT_READY rather than inheriting
+// the default provider's status, per 1.7.1 / 1.7.3 and the section 1.7 lifecycle diagram.
+func TestDomainStateWhileProviderInitializing(t *testing.T) {
+	api := newAPI()
+	t.Cleanup(func() {
+		_ = api.Shutdown(context.Background()) //nolint:usetesting
+	})
+
+	if err := api.SetProviderAndWait(t.Context(), NoopProvider{}); err != nil {
+		t.Fatalf("failed to set up default provider: %v", err)
+	}
+	if got := api.eventExecutor.State(defaultDomain); got != ReadyState {
+		t.Fatalf("expected the default provider to be READY, got %q", got)
+	}
+
+	initializing := struct {
+		FeatureProvider
+		StateHandler
+		EventHandler
+	}{
+		NoopProvider{},
+		&stateHandlerForTests{
+			initF: func(EvaluationContext) error {
+				// Block until test cleanup so the provider never leaves NOT_READY.
+				<-t.Context().Done()
+				return nil
+			},
+		},
+		&ProviderEventing{},
+	}
+
+	if _, err := api.setDomainProvider(t.Context(), "foo", initializing); err != nil {
+		t.Fatalf("failed to set up the domain provider: %v", err)
+	}
+
+	if got := api.eventExecutor.State("foo"); got != NotReadyState {
+		t.Errorf("expected domain \"foo\" to report NOT_READY while its provider initializes, got %q", got)
+	}
+}


### PR DESCRIPTION
## Motivation & Context

Fixes #550

`loadState` falls back to the **default** provider's state when a domain has no entry of its own, and `e.states` is written only from `triggerEvent`, which runs from `initNew`'s goroutine after initialization completes. `registerNamedEventingProvider` never seeds an entry for the domain.

So in the window between `SetNamedProvider("foo", p)` and `p` finishing initialization, a client on domain `foo` inherits the default provider's status. When the default is READY, the domain client reports READY, `Client.evaluate` therefore skips its NOT_READY short-circuit, and the evaluation runs against a provider whose `Init` has not returned.

Per [1.7.1](https://openfeature.dev/specification/sections/flag-evaluation#requirement-171) / [1.7.3](https://openfeature.dev/specification/sections/flag-evaluation#requirement-173) and the §1.7 lifecycle diagram (`[*] --> NOT_READY`), a provider is READY only after it emits `PROVIDER_READY`.

## Change

Seed `NotReadyState` when a provider is registered, in both `registerDefaultProvider` and `registerNamedEventingProvider`.

This is safe to do unconditionally because registration is always followed by `initNew`, which always calls `triggerEvent` — on the success and the error path alike — and `triggerEvent` writes the real state for every domain bound to that provider. The seeded value therefore only ever covers the registration window; it cannot leave a domain stuck at NOT_READY, including when the same provider instance is bound to several domains.

Java, JS and Python all install a NOT_READY state synchronously at registration and before init.

## Testing

New `TestDomainStateWhileProviderInitializing`: sets a READY default provider, registers a domain provider whose `Init` blocks, and asserts the domain reports NOT_READY. On `main` it reports `READY`.

`make test` and `make lint` are clean; no existing test changed.
