### PR TITLE
docs: align genericResolve godoc with the implementation

### DIFF
--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -157,7 +157,7 @@ func (i InMemoryProvider) find(flag string) (*InMemoryFlag, *openfeature.Provide
 // helpers
 
 // genericResolve is a helper to extract type verified evaluation and fill openfeature.ProviderResolutionDetail.
-// It coerces smaller numeric types to their canonical forms (int* -> int64, int* | float32 -> float64)
+// It coerces smaller numeric types to their canonical forms (int* -> int64, float32 -> float64)
 // to provide a more forgiving API for test flag configuration.
 //
 // Note: Only signed integer types are supported for conversion. Unsigned integer types


### PR DESCRIPTION
Follow-up from the review on #565: the godoc said int values convert to float64 as a primary form, but the canonical mapping is int* to int64 and float32 to float64.