### PR TITLE
fix(multi): report missing provider not-ready and fatal errors in resolution details

### DIFF
--- a/openfeature/multi/isolation.go
+++ b/openfeature/multi/isolation.go
@@ -124,8 +124,11 @@ func (h *hookIsolator) ObjectEvaluation(ctx context.Context, flag string, defaul
 
 // toProviderResolutionDetail Converts a [of.InterfaceEvaluationDetails] to a [of.ProviderResolutionDetail].
 func toProviderResolutionDetail(evalDetails of.InterfaceEvaluationDetails) of.ProviderResolutionDetail {
-	var resolutionErr of.ResolutionError
-	var reason of.Reason
+	var (
+		resolutionErr of.ResolutionError
+		reason        of.Reason
+	)
+
 	switch evalDetails.ErrorCode {
 	case of.GeneralCode:
 		resolutionErr = of.NewGeneralResolutionError(evalDetails.ErrorMessage)
@@ -145,7 +148,19 @@ func toProviderResolutionDetail(evalDetails of.InterfaceEvaluationDetails) of.Pr
 	case of.InvalidContextCode:
 		resolutionErr = of.NewInvalidContextResolutionError(evalDetails.ErrorMessage)
 		reason = of.ErrorReason
+	case of.ProviderNotReadyCode:
+		resolutionErr = of.NewProviderNotReadyResolutionError(evalDetails.ErrorMessage)
+		reason = of.ErrorReason
+	case of.ProviderFatalCode:
+		resolutionErr = of.NewProviderFatalResolutionError(evalDetails.ErrorMessage)
+		reason = of.ErrorReason
+	default:
+		if evalDetails.ErrorCode != "" {
+			resolutionErr = of.NewGeneralResolutionError(evalDetails.ErrorMessage)
+			reason = of.ErrorReason
+		}
 	}
+
 	return of.ProviderResolutionDetail{
 		ResolutionError: resolutionErr,
 		Reason:          reason,

--- a/openfeature/multi/isolation_test.go
+++ b/openfeature/multi/isolation_test.go
@@ -1,14 +1,35 @@
 package multi
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	of "github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/isolated"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+// stateHandler is a minimal StateHandler with configurable callbacks for tests.
+type stateHandler struct {
+	initF     func(of.EvaluationContext) error
+	shutdownF func()
+}
+
+func (s stateHandler) Init(e of.EvaluationContext) error {
+	if s.initF != nil {
+		return s.initF(e)
+	}
+	return nil
+}
+
+func (s stateHandler) Shutdown() {
+	if s.shutdownF != nil {
+		s.shutdownF()
+	}
+}
 
 func Test_HookIsolator_BeforeCapturesData(t *testing.T) {
 	hookCtx := of.NewHookContext(
@@ -90,6 +111,277 @@ func Test_HookIsolator_ExecutesHooksDuringEvaluation_BeforeErrorAbortsExecution(
 	}, nil)
 	result := isolator.BooleanEvaluation(t.Context(), "test-flag", false, of.FlattenedContext{"targetingKey": "anon"})
 	assert.False(t, result.Value)
+}
+
+func Test_toProviderResolutionDetail(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            of.InterfaceEvaluationDetails
+		wantErrorCode    of.ErrorCode
+		wantReason       of.Reason
+		wantErr          bool
+		wantVariant      string
+		wantFlagMetadata of.FlagMetadata
+	}{
+		{
+			name: "ProviderNotReadyCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.ProviderNotReadyCode,
+						ErrorMessage: "not ready",
+					},
+				},
+			},
+			wantErrorCode: of.ProviderNotReadyCode,
+			wantReason:    of.ErrorReason,
+			wantErr:       true,
+		},
+		{
+			name: "ProviderFatalCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.ProviderFatalCode,
+						ErrorMessage: "fatal error",
+					},
+				},
+			},
+			wantErrorCode: of.ProviderFatalCode,
+			wantReason:    of.ErrorReason,
+			wantErr:       true,
+		},
+		{
+			name: "GeneralCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.GeneralCode,
+						ErrorMessage: "general error",
+					},
+				},
+			},
+			wantErrorCode: of.GeneralCode,
+			wantReason:    of.ErrorReason,
+			wantErr:       true,
+		},
+		{
+			name: "FlagNotFoundCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.FlagNotFoundCode,
+						ErrorMessage: "flag not found",
+					},
+				},
+			},
+			wantErrorCode: of.FlagNotFoundCode,
+			wantReason:    of.DefaultReason,
+			wantErr:       true,
+		},
+		{
+			name: "TargetingKeyMissingCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.TargetingKeyMissingCode,
+						ErrorMessage: "targeting key missing",
+					},
+				},
+			},
+			wantErrorCode: of.TargetingKeyMissingCode,
+			wantReason:    of.TargetingMatchReason,
+			wantErr:       true,
+		},
+		{
+			name: "TypeMismatchCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.TypeMismatchCode,
+						ErrorMessage: "type mismatch",
+					},
+				},
+			},
+			wantErrorCode: of.TypeMismatchCode,
+			wantReason:    of.ErrorReason,
+			wantErr:       true,
+		},
+		{
+			name: "ParseErrorCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.ParseErrorCode,
+						ErrorMessage: "parse error",
+					},
+				},
+			},
+			wantErrorCode: of.ParseErrorCode,
+			wantReason:    of.ErrorReason,
+			wantErr:       true,
+		},
+		{
+			name: "InvalidContextCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.InvalidContextCode,
+						ErrorMessage: "invalid context",
+					},
+				},
+			},
+			wantErrorCode: of.InvalidContextCode,
+			wantReason:    of.ErrorReason,
+			wantErr:       true,
+		},
+		{
+			name: "unknown non-empty error code defaults to GeneralCode",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.ErrorCode("UNKNOWN_CODE"),
+						ErrorMessage: "some unknown error",
+					},
+				},
+			},
+			wantErrorCode: of.GeneralCode,
+			wantReason:    of.ErrorReason,
+			wantErr:       true,
+		},
+		{
+			name: "empty error code produces no error",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode: "",
+					},
+				},
+			},
+			wantErrorCode: "",
+			wantReason:    "",
+			wantErr:       false,
+		},
+		{
+			name: "variant and flag metadata are preserved",
+			input: of.InterfaceEvaluationDetails{
+				EvaluationDetails: of.EvaluationDetails{
+					ResolutionDetail: of.ResolutionDetail{
+						ErrorCode:    of.ProviderFatalCode,
+						ErrorMessage: "fatal",
+						Variant:      "variant-a",
+						FlagMetadata: of.FlagMetadata{"key": "value"},
+					},
+				},
+			},
+			wantErrorCode:    of.ProviderFatalCode,
+			wantReason:       of.ErrorReason,
+			wantErr:          true,
+			wantVariant:      "variant-a",
+			wantFlagMetadata: of.FlagMetadata{"key": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toProviderResolutionDetail(tt.input)
+			assert.Equal(t, tt.wantReason, result.Reason)
+			assert.Equal(t, tt.wantVariant, result.Variant)
+			assert.Equal(t, tt.wantFlagMetadata, result.FlagMetadata)
+
+			err := result.Error()
+			if tt.wantErr {
+				require.Error(t, err)
+				detail := result.ResolutionDetail()
+				assert.Equal(t, tt.wantErrorCode, detail.ErrorCode)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newTestOnlyFirstProviderStrategy(providers []NamedProvider) StrategyFn[FlagTypes] {
+	return newTestOnlyFirstProviderStrategyFn[FlagTypes](providers)
+}
+
+func newTestOnlyFirstProviderStrategyFn[T FlagTypes](providers []NamedProvider) StrategyFn[T] {
+	return func(ctx context.Context, flag string, defaultValue T, flatCtx of.FlattenedContext) of.GenericResolutionDetail[T] {
+		return Evaluate(ctx, providers[0], flag, defaultValue, flatCtx)
+	}
+}
+
+func Test_HookIsolator_Evaluation_ProviderNotReadyCode(t *testing.T) {
+	done := make(chan struct{})
+	api := isolated.NewAPI()
+	t.Cleanup(func() {
+		<-done
+		_ = api.Shutdown(context.Background()) //nolint:usetesting
+	})
+
+	p := struct {
+		of.FeatureProvider
+		of.StateHandler
+	}{
+		FeatureProvider: of.NoopProvider{},
+		StateHandler: stateHandler{
+			initF: func(e of.EvaluationContext) error {
+				<-t.Context().Done()
+				close(done)
+				return nil
+			},
+		},
+	}
+
+	mp, err := NewProvider(
+		StrategyCustom,
+		WithProvider("never-ready", p),
+		WithCustomStrategy(newTestOnlyFirstProviderStrategy),
+	)
+	require.NoError(t, err)
+	err = api.SetProvider(t.Context(), mp)
+	require.NoError(t, err)
+
+	client := api.NewClient()
+	result, err := client.BooleanValueDetails(t.Context(), "test-flag", false, of.NewEvaluationContext("test", nil))
+	require.Error(t, err)
+	assert.False(t, result.Value)
+	assert.Equal(t, of.ProviderNotReadyCode, result.ErrorCode)
+	assert.Equal(t, of.ErrorReason, result.Reason)
+}
+
+func Test_HookIsolator_Evaluation_ProviderFatalCode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := of.NewMockFeatureProvider(ctrl)
+	provider.EXPECT().Hooks().Return([]of.Hook{}).MinTimes(1)
+	provider.EXPECT().Metadata().Return(of.Metadata{Name: t.Name()}).MinTimes(1)
+	provider.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(of.BoolResolutionDetail{
+		Value: false,
+		ProviderResolutionDetail: of.ProviderResolutionDetail{
+			ResolutionError: of.NewProviderFatalResolutionError("fatal"),
+			Reason:          of.ErrorReason,
+		},
+	})
+
+	api := isolated.NewAPI()
+	t.Cleanup(func() {
+		_ = api.Shutdown(context.Background()) //nolint:usetesting
+	})
+	mp, err := NewProvider(
+		StrategyCustom,
+		WithProvider("fatal", provider),
+		WithCustomStrategy(newTestOnlyFirstProviderStrategy),
+	)
+	require.NoError(t, err)
+	err = api.SetProviderAndWait(t.Context(), mp)
+	require.NoError(t, err)
+
+	client := api.NewClient()
+	result, err := client.BooleanValueDetails(t.Context(), "test-flag", false, of.NewEvaluationContext("test", nil))
+	require.Error(t, err)
+	assert.False(t, result.Value)
+	assert.Equal(t, of.ProviderFatalCode, result.ErrorCode)
+	assert.Equal(t, of.ErrorReason, result.Reason)
 }
 
 func Test_HookIsolator_ExecutesHooksDuringEvaluation_WithAfterError(t *testing.T) {

--- a/openfeature/multi/multiprovider.go
+++ b/openfeature/multi/multiprovider.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	of "github.com/open-feature/go-sdk/openfeature"
 	"golang.org/x/sync/errgroup"
@@ -35,7 +36,7 @@ type (
 	Provider struct {
 		providers          []NamedProvider
 		metadata           of.Metadata
-		initialized        bool
+		initialized        atomic.Bool
 		overallStatus      of.State
 		overallStatusLock  sync.RWMutex
 		providerStatus     map[string]of.State
@@ -426,7 +427,7 @@ func (p *Provider) InitWithContext(ctx context.Context, evalCtx of.EvaluationCon
 	}
 
 	p.setStatus(of.ReadyState)
-	p.initialized = true
+	p.initialized.Store(true)
 	return nil
 }
 
@@ -568,7 +569,7 @@ func (p *Provider) Shutdown() {
 
 // ShutdownWithContext shuts down all internal [of.FeatureProvider] instances and internal event listeners
 func (p *Provider) ShutdownWithContext(ctx context.Context) error {
-	if !p.initialized {
+	if !p.initialized.Load() {
 		// Don't do anything if we were never initialized
 		p.logger.LogAttrs(ctx, slog.LevelDebug, "provider not initialized, skipping shutdown")
 		return nil
@@ -603,7 +604,7 @@ func (p *Provider) ShutdownWithContext(ctx context.Context) error {
 	p.workerGroup.Wait()
 	p.logger.LogAttrs(ctx, slog.LevelDebug, "worker shutdown completed")
 	p.setStatus(of.NotReadyState)
-	p.initialized = false
+	p.initialized.Store(false)
 	p.logger.LogAttrs(ctx, slog.LevelDebug, "provider shutdown completed")
 
 	return errs
@@ -631,7 +632,7 @@ func (p *Provider) EventChannel() <-chan of.Event {
 // Track implements the [of.Tracker] interface by forwarding tracking calls to all internal providers that
 // are in ready state and implement the [of.Tracker] interface.
 func (p *Provider) Track(ctx context.Context, trackingEventName string, evaluationContext of.EvaluationContext, details of.TrackingEventDetails) {
-	if !p.initialized {
+	if !p.initialized.Load() {
 		// Don't do anything if we were never initialized
 		p.logger.LogAttrs(ctx, slog.LevelDebug, "provider not initialized, skipping tracking", slog.String("tracking-event", trackingEventName))
 		return


### PR DESCRIPTION
## This PR

Fixes an issue where ProviderNotReadyCode and ProviderFatalCode were not handled by toProviderResolutionDetail, causing ProviderResolutionDetail.Error() to incorrectly return nil.

### Related Issues

Fixes #543

### Notes

There is a minimal change for `initialized` to prevent racing in tests.
