### PR TITLE
fix: copy the caller's map in NewHookHints

### DIFF
--- a/openfeature/hooks.go
+++ b/openfeature/hooks.go
@@ -1,6 +1,9 @@
 package openfeature
 
-import "context"
+import (
+	"context"
+	"maps"
+)
 
 // Hook allows application developers to add arbitrary behavior to the flag evaluation lifecycle.
 // They operate similarly to middleware in many web frameworks.
@@ -18,12 +21,19 @@ type HookHints struct {
 }
 
 // NewHookHints constructs HookHints
+//
+// mapOfHints - arbitrary data made available to hooks. The map is copied, so
+// changes the caller makes to it afterwards are not reflected in the hints.
+// The copy is shallow: values that are themselves mutable remain shared.
 func NewHookHints(mapOfHints map[string]any) HookHints {
-	return HookHints{mapOfHints: mapOfHints}
+	// copy hints to new map to avoid reference being externally available, thereby enforcing immutability
+	hints := make(map[string]any, len(mapOfHints))
+	maps.Copy(hints, mapOfHints)
+
+	return HookHints{mapOfHints: hints}
 }
 
 // Value returns the value at the given key in the underlying map.
-// Maintains immutability of the map.
 func (h HookHints) Value(key string) any {
 	return h.mapOfHints[key]
 }

--- a/openfeature/hooks_test.go
+++ b/openfeature/hooks_test.go
@@ -99,6 +99,23 @@ func TestRequirement_4_2_2_1(t *testing.T) {
 	if caser.String(fieldName) == fieldName {
 		t.Errorf("field %s is uppercased and therefore mutable", fieldName)
 	}
+
+	// The unexported field only keeps the reference from being reachable outside
+	// the package. The caller still holds the map it passed in, so the hints are
+	// only immutable if NewHookHints copies it.
+	source := map[string]any{"foo": "bar"}
+	hints := NewHookHints(source)
+
+	source["foo"] = "baz"
+	source["added"] = "after construction"
+
+	if value := hints.Value("foo"); value != "bar" {
+		t.Errorf("expected hint to be unaffected by the caller, got %v", value)
+	}
+
+	if value := hints.Value("added"); value != nil {
+		t.Errorf("expected key added after construction to be absent, got %v", value)
+	}
 }
 
 // Condition: The client `metadata` field in the `hook context` MUST be immutable.


### PR DESCRIPTION
This PR

- copies the caller's map in NewHookHints, matching NewEvaluationContext in the same package
- moves the immutability claim off Value onto the constructor, and states that the copy is shallow
- extends TestRequirement_4_2_2_1 with an assertion that actually fails without the fix

NewHookHints stored the map by reference, so the caller could mutate the hints after construction and every hook would observe the change:

Value("k") = after                 (want "before")
Value("added-later") = surprise    (want nil)

Related Issues

Fixes #562

Notes

- The assertion goes in TestRequirement_4_2_2_1 rather than 4.5.3, per the discussion on the issue: immutability of the hints structure is the property the copy establishes, while 4.5.3 constrains the hook rather than the caller. TestRequirement_4_5_3 is left as it is.
- Both of those tests previously asserted only that mapOfHints is unexported. That keeps the reference out of reach from outside the package, but not the contents, since the caller still holds the map it passed in — so neither test could fail today, and neither would have caught this.
- The copy is shallow, so values that are themselves mutable stay shared. That matches Collections.unmodifiableMap in the Java SDK and Object.freeze in the JS SDK, so it is parity rather than a shortfall. I verified the boundary behaves as documented but did not add a test for it, since asserting it would lock the shallowness in.
- The doc comment on Value claimed to maintain immutability of the map, which only became true once the constructor copies. Moved rather than deleted.

How to test

go test -tags testtools -race -count=1 -run 'TestRequirement_4_2_2_1' ./openfeature/