### PR TITLE
fix: resolve disabled flags without an error

### DIFF
--- a/openfeature/memprovider/in_memory_provider.go
+++ b/openfeature/memprovider/in_memory_provider.go
@@ -230,8 +230,7 @@ func (flag *InMemoryFlag) Resolve(defaultValue any, flatCtx openfeature.Flattene
 	// check the state
 	if flag.State == Disabled {
 		return defaultValue, openfeature.ProviderResolutionDetail{
-			ResolutionError: openfeature.NewGeneralResolutionError("flag is disabled"),
-			Reason:          openfeature.DisabledReason,
+			Reason: openfeature.DisabledReason,
 		}
 	}
 

--- a/openfeature/memprovider/in_memory_provider_test.go
+++ b/openfeature/memprovider/in_memory_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/isolated"
 )
 
 func TestInMemoryProvider_boolean(t *testing.T) {
@@ -406,7 +407,36 @@ func TestInMemoryProvider_Disabled(t *testing.T) {
 		}
 
 		if evaluation.Reason != openfeature.DisabledReason {
-			t.Errorf("incorrect reason, expected %v, got %v", openfeature.ErrorReason, evaluation.Reason)
+			t.Errorf("incorrect reason, expected %v, got %v", openfeature.DisabledReason, evaluation.Reason)
+		}
+
+		if err := evaluation.Error(); err != nil {
+			t.Errorf("expected no error for a disabled flag, got %v", err)
+		}
+	})
+
+	// The provider-level assertions above cannot observe the reason being
+	// overwritten, because that happens in the client. Drive it through an
+	// isolated API so the global singleton is untouched.
+	t.Run("test disabled flag through the client", func(t *testing.T) {
+		api := isolated.NewAPI()
+		t.Cleanup(func() { _ = api.Shutdown(ctx) })
+
+		if err := api.SetProviderAndWait(ctx, memoryProvider); err != nil {
+			t.Fatalf("failed to set provider: %v", err)
+		}
+
+		details, err := api.NewClient().BooleanValueDetails(ctx, "boolFlag", false, openfeature.EvaluationContext{})
+		if err != nil {
+			t.Errorf("expected no error for a disabled flag, got %v", err)
+		}
+
+		if details.Reason != openfeature.DisabledReason {
+			t.Errorf("incorrect reason, expected %v, got %v", openfeature.DisabledReason, details.Reason)
+		}
+
+		if details.Value != false {
+			t.Errorf("incorrect evaluation, expected %v, got %v", false, details.Value)
 		}
 	})
 }


### PR DESCRIPTION
This PR

- drops the ResolutionError from InMemoryFlag.Resolve's disabled branch, so a disabled flag resolves to the default with reason DISABLED and no error
- extends TestInMemoryProvider_Disabled with an error assertion and a client-level subtest

ProviderResolutionDetail.Error() is non-nil whenever a code is set, so Client.evaluate treated a disabled flag as abnormal execution, overwrote DisabledReason with ErrorReason and returned a GENERAL error to the caller:

value=false reason="ERROR" errorCode="GENERAL" errorMessage="flag is disabled"
err=error code: GENERAL: flag is disabled

After the fix, reason DISABLED, the default value, and no error.

Related Issues

Fixes #552

Notes

- Dropping the ResolutionError is the whole fix. Resolve already returns defaultValue on that branch and genericResolve asserts it against itself, so the value and the reason come out right on their own.
- The existing test disabled flag subtest asserts only Value and Reason, both of which are already correct at the provider level, so it passes unchanged before and after this change. I have added an error assertion to it, otherwise nothing in the suite would catch a regression here.
- The client-level subtest is the one that matters, since the reason is overwritten in Client.evaluate and a provider-level assertion cannot observe that. It uses isolated.NewAPI() so the global singleton is left alone — this package's tests have not driven the client before, and I did not want to introduce shared provider state into them.
- Worth recording for anyone reading the issue: the DISABLED scenarios cited there are in evaluation_v2.feature in the spec repo. This repo's test-harness submodule is the flagd harness, and e2e runs only evaluation.feature from it, which has no disabled-flag scenarios. So e2e does not cover this today, which is likely why it went unnoticed. The parity argument with the Java and JS in-memory providers, both of which return DISABLED with no error, is what the fix rests on.
- One line outside the strict fix: the reason assertion's failure message printed ErrorReason as its expectation while checking DisabledReason. It is inside the block being changed, so I corrected it rather than leave a misleading message next to a new assertion. Happy to split it out if you would rather.
- On sequencing with #539: the test uses := throughout and never names memprovider.InMemoryProvider explicitly, so it survives whichever of the two merges first.

How to test

go test -tags testtools -race -count=1 -run 'TestInMemoryProvider_Disabled' ./openfeature/memprovider/