### PR TITLE
fix: return an empty flag metadata record on evaluate's early returns

### DIFF
--- a/openfeature/client.go
+++ b/openfeature/client.go
@@ -659,6 +659,10 @@ func (c *Client) evaluate(
 		EvaluationDetails: EvaluationDetails{
 			FlagKey:  flag,
 			FlagType: flagType,
+			ResolutionDetail: ResolutionDetail{
+				// empty record rather than nil on the early returns, see #542
+				FlagMetadata: FlagMetadata{},
+			},
 		},
 	}
 

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -695,11 +695,11 @@ func TestRequirement_1_4_12(t *testing.T) {
 	}
 }
 
-// Requirement_1_4_13
+// Requirement_1_4_14
 // If the `flag metadata` field in the `flag resolution` structure returned by the configured `provider` is set,
 // the `evaluation details` structure's `flag metadata` field MUST contain that value. Otherwise,
 // it MUST contain an empty record.
-func TestRequirement_1_4_13(t *testing.T) {
+func TestRequirement_1_4_14(t *testing.T) {
 	flagKey := "flag-key"
 	evalCtx := EvaluationContext{}
 	flatCtx := flattenContext(evalCtx)

--- a/openfeature/client_test.go
+++ b/openfeature/client_test.go
@@ -730,6 +730,112 @@ func TestRequirement_1_4_13(t *testing.T) {
 		}
 	})
 
+	// early returns that never reach a provider resolution, see #542
+	t.Run("No metadata on the invalid UTF-8 flag key return", func(t *testing.T) {
+		t.Cleanup(resetSingleton)
+
+		mocks := hydratedMocksForClientTests(t, 0)
+		client := newClient("test-client", mocks.providerBinding, mocks.clientHandlerAPI)
+
+		evDetails, err := client.BooleanValueDetails(t.Context(), "invalid\xf0\x28", true, EvaluationContext{})
+		if err == nil {
+			t.Error("expected an error for an invalid UTF-8 flag key, got nil")
+		}
+		if !reflect.DeepEqual(evDetails.FlagMetadata, FlagMetadata{}) {
+			// %#v: nil and an empty map both print as "map[]"
+			t.Errorf("expected %#v, got %#v", FlagMetadata{}, evDetails.FlagMetadata)
+		}
+	})
+
+	t.Run("No metadata on the before hook error return", func(t *testing.T) {
+		t.Cleanup(resetSingleton)
+
+		mocks := hydratedMocksForClientTests(t, 1)
+		client := newClient("test-client", mocks.providerBinding, mocks.clientHandlerAPI)
+
+		mockHook := NewMockHook(gomock.NewController(t))
+		mockHook.EXPECT().Before(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("forced"))
+		mockHook.EXPECT().Error(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		mockHook.EXPECT().Finally(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+
+		evDetails, err := client.BooleanValueDetails(t.Context(), flagKey, true, EvaluationContext{}, WithHooks(mockHook))
+		if err == nil {
+			t.Error("expected an error from the failing before hook, got nil")
+		}
+		if !reflect.DeepEqual(evDetails.FlagMetadata, FlagMetadata{}) {
+			t.Errorf("expected %#v, got %#v", FlagMetadata{}, evDetails.FlagMetadata)
+		}
+	})
+
+	t.Run("No metadata when the provider is NOT_READY", func(t *testing.T) {
+		api := newAPI()
+		t.Cleanup(func() {
+			_ = api.Shutdown(context.Background()) //nolint:usetesting
+		})
+
+		notReadyProvider := struct {
+			FeatureProvider
+			StateHandler
+			EventHandler
+		}{
+			NoopProvider{},
+			&stateHandlerForTests{
+				initF: func(e EvaluationContext) error {
+					// Block until test cleanup to keep provider in NOT_READY state
+					<-t.Context().Done()
+					return nil
+				},
+			},
+			&ProviderEventing{},
+		}
+
+		if err := api.SetProvider(t.Context(), notReadyProvider); err != nil {
+			t.Fatalf("failed to set up provider: %v", err)
+		}
+
+		evDetails, err := api.NewClient().BooleanValueDetails(t.Context(), flagKey, true, EvaluationContext{})
+		if err == nil {
+			t.Error("expected an error while the provider is NOT_READY, got nil")
+		}
+		if !reflect.DeepEqual(evDetails.FlagMetadata, FlagMetadata{}) {
+			t.Errorf("expected %#v, got %#v", FlagMetadata{}, evDetails.FlagMetadata)
+		}
+	})
+
+	t.Run("No metadata when the provider is FATAL", func(t *testing.T) {
+		api := newAPI()
+		t.Cleanup(func() {
+			_ = api.Shutdown(context.Background()) //nolint:usetesting
+		})
+
+		fatalProvider := struct {
+			FeatureProvider
+			StateHandler
+			EventHandler
+		}{
+			NoopProvider{},
+			&stateHandlerForTests{
+				initF: func(e EvaluationContext) error {
+					return &ProviderInitError{ErrorCode: ProviderFatalCode}
+				},
+			},
+			&ProviderEventing{},
+		}
+
+		if err := api.SetProviderAndWait(t.Context(), fatalProvider, WithDomain(t.Name())); err == nil {
+			t.Error("provider registration was expected to fail but succeeded unexpectedly")
+		}
+
+		evDetails, err := api.NewClient(WithDomain(t.Name())).
+			BooleanValueDetails(t.Context(), flagKey, true, EvaluationContext{})
+		if err == nil {
+			t.Error("expected an error while the provider is FATAL, got nil")
+		}
+		if !reflect.DeepEqual(evDetails.FlagMetadata, FlagMetadata{}) {
+			t.Errorf("expected %#v, got %#v", FlagMetadata{}, evDetails.FlagMetadata)
+		}
+	})
+
 	t.Run("Metadata present", func(t *testing.T) {
 		t.Cleanup(resetSingleton)
 

--- a/openfeature/multi/isolation.go
+++ b/openfeature/multi/isolation.go
@@ -183,7 +183,7 @@ func (h *hookIsolator) evaluate(ctx context.Context, flag string, flagType of.Ty
 			Reason:       of.ErrorReason,
 			ErrorCode:    of.GeneralCode,
 			ErrorMessage: err.Error(),
-			FlagMetadata: nil,
+			FlagMetadata: of.FlagMetadata{},
 		}
 		return evalDetails
 	}

--- a/openfeature/multi/isolation_test.go
+++ b/openfeature/multi/isolation_test.go
@@ -90,6 +90,8 @@ func Test_HookIsolator_ExecutesHooksDuringEvaluation_BeforeErrorAbortsExecution(
 	}, nil)
 	result := isolator.BooleanEvaluation(t.Context(), "test-flag", false, of.FlattenedContext{"targetingKey": "anon"})
 	assert.False(t, result.Value)
+	// empty record rather than nil, see #542
+	assert.Equal(t, of.FlagMetadata{}, result.FlagMetadata)
 }
 
 func Test_HookIsolator_ExecutesHooksDuringEvaluation_WithAfterError(t *testing.T) {


### PR DESCRIPTION
## This PR

- initialises `FlagMetadata` once at the top of `evaluate`, so the early returns yield an empty record instead of nil
- fixes the same gap in `multi`'s `hookIsolator`, which set `FlagMetadata: nil` explicitly on its before-hook error path
- adds subtests covering all four returns, and renames the test they live in to `TestRequirement_1_4_14`

Four of `evaluate`'s returns never reach a provider resolution, so they had no metadata to inherit and handed back nil: the invalid UTF-8 flag key check, the NOT_READY and FATAL short-circuits, and the before-hook error. Per 1.4.14 the field must contain an empty record when the provider sets none.

### Related Issues

Fixes #542

### Notes

- Initialising at the top rather than per-path is deliberate. `evalDetails.ResolutionDetail = resolution.ResolutionDetail()` further down assigns wholesale, so provider-supplied metadata still wins and nothing on the normal path changes.
- The after-hook and resolution-error returns already yielded an empty record, because both sit below that assignment. So it is four returns, not five — the issue body says five.
- Scope is metadata only. The error-code gap on these same returns is #567, being handled in #568.
- On overlap: #568 edits the UTF-8 and before-hook return blocks, and #572 is in `multi/isolation.go`. Neither touches metadata. I have kept the new tests as subtests of `TestRequirement_1_4_14` rather than new top-level functions, since #568 is adding those to `client_test.go`, and extended the existing `Test_HookIsolator_ExecutesHooksDuringEvaluation_BeforeErrorAbortsExecution` rather than adding a test to `isolation_test.go`, which #572 also touches.
- The test these subtests live in was named `TestRequirement_1_4_13` while its doc comment quoted 1.4.14. Renamed to `TestRequirement_1_4_14` per review: 1.4.13 is the error message MAY, and the empty-record MUST is 1.4.14. That is one entry off the numbering drift tracked in #526.
- The new assertions use `%#v`. With `%v` a nil map and an empty map both print as `map[]`, which would make the one distinction these tests exist to check invisible in a failure. The pre-existing `No Metadata` subtest has the same issue; I left it alone as out of scope.

### How to test

```
go test -tags testtools -race -count=1 -run 'TestRequirement_1_4_14' ./openfeature/
go test -tags testtools -race -count=1 -run 'Test_HookIsolator' ./openfeature/multi/
```
