### PR TITLE
fix: omit empty feature flag context id

### DIFF
--- a/openfeature/telemetry/telemetry.go
+++ b/openfeature/telemetry/telemetry.go
@@ -64,7 +64,7 @@ func CreateEvaluationEvent(hookContext openfeature.HookContext, details openfeat
 		attributes[ResultValueKey] = details.Value
 	}
 
-	if contextID, ok := details.FlagMetadata[flagMetaContextIDKey]; ok && contextID != "" {
+	if contextID, ok := details.FlagMetadata[flagMetaContextIDKey].(string); ok && contextID != "" {
 		attributes[ContextIDKey] = contextID
 	} else if targetingKey := hookContext.EvaluationContext().TargetingKey(); targetingKey != "" {
 		attributes[ContextIDKey] = targetingKey

--- a/openfeature/telemetry/telemetry.go
+++ b/openfeature/telemetry/telemetry.go
@@ -64,9 +64,10 @@ func CreateEvaluationEvent(hookContext openfeature.HookContext, details openfeat
 		attributes[ResultValueKey] = details.Value
 	}
 
-	attributes[ContextIDKey] = hookContext.EvaluationContext().TargetingKey()
-	if contextID, ok := details.FlagMetadata[flagMetaContextIDKey]; ok {
+	if contextID, ok := details.FlagMetadata[flagMetaContextIDKey]; ok && contextID != "" {
 		attributes[ContextIDKey] = contextID
+	} else if targetingKey := hookContext.EvaluationContext().TargetingKey(); targetingKey != "" {
+		attributes[ContextIDKey] = targetingKey
 	}
 
 	if setID, ok := details.FlagMetadata[flagMetaFlagSetIDKey]; ok {

--- a/openfeature/telemetry/telemetry_context_id_test.go
+++ b/openfeature/telemetry/telemetry_context_id_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/open-feature/go-sdk/openfeature"
 )
 
+// TestCreateEvaluationEvent_ContextID verifies context ID precedence, fallback, and omission.
 func TestCreateEvaluationEvent_ContextID(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -40,9 +41,35 @@ func TestCreateEvaluationEvent_ContextID(t *testing.T) {
 			wantAttribute: true,
 		},
 		{
+			name:         "nil metadata context uses targeting key fallback",
+			targetingKey: "targeting-context",
+			flagMetadata: openfeature.FlagMetadata{
+				flagMetaContextIDKey: nil,
+			},
+			wantContextID: "targeting-context",
+			wantAttribute: true,
+		},
+		{
+			name:         "non-string metadata context uses targeting key fallback",
+			targetingKey: "targeting-context",
+			flagMetadata: openfeature.FlagMetadata{
+				flagMetaContextIDKey: true,
+			},
+			wantContextID: "targeting-context",
+			wantAttribute: true,
+		},
+		{
 			name:          "context attribute is omitted when unavailable",
 			targetingKey:  "",
 			flagMetadata:  openfeature.FlagMetadata{},
+			wantAttribute: false,
+		},
+		{
+			name:         "invalid metadata is omitted without targeting key",
+			targetingKey: "",
+			flagMetadata: openfeature.FlagMetadata{
+				flagMetaContextIDKey: nil,
+			},
 			wantAttribute: false,
 		},
 	}

--- a/openfeature/telemetry/telemetry_context_id_test.go
+++ b/openfeature/telemetry/telemetry_context_id_test.go
@@ -1,0 +1,86 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+func TestCreateEvaluationEvent_ContextID(t *testing.T) {
+	tests := []struct {
+		name          string
+		targetingKey  string
+		flagMetadata  openfeature.FlagMetadata
+		wantContextID string
+		wantAttribute bool
+	}{
+		{
+			name:         "metadata takes precedence",
+			targetingKey: "targeting-context",
+			flagMetadata: openfeature.FlagMetadata{
+				flagMetaContextIDKey: "metadata-context",
+			},
+			wantContextID: "metadata-context",
+			wantAttribute: true,
+		},
+		{
+			name:          "targeting key is used as fallback",
+			targetingKey:  "targeting-context",
+			flagMetadata:  openfeature.FlagMetadata{},
+			wantContextID: "targeting-context",
+			wantAttribute: true,
+		},
+		{
+			name:         "empty metadata context uses targeting key fallback",
+			targetingKey: "targeting-context",
+			flagMetadata: openfeature.FlagMetadata{
+				flagMetaContextIDKey: "",
+			},
+			wantContextID: "targeting-context",
+			wantAttribute: true,
+		},
+		{
+			name:          "context attribute is omitted when unavailable",
+			targetingKey:  "",
+			flagMetadata:  openfeature.FlagMetadata{},
+			wantAttribute: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagKey := "test-flag"
+			providerMetadata := openfeature.Metadata{Name: "test-provider"}
+			clientMetadata := openfeature.NewClientMetadata("test-client")
+			evaluationContext := openfeature.NewEvaluationContext(tt.targetingKey, map[string]any{})
+			hookContext := openfeature.NewHookContext(
+				flagKey,
+				openfeature.Boolean,
+				true,
+				clientMetadata,
+				providerMetadata,
+				evaluationContext,
+			)
+			details := openfeature.InterfaceEvaluationDetails{
+				Value: true,
+				EvaluationDetails: openfeature.EvaluationDetails{
+					FlagKey:  flagKey,
+					FlagType: openfeature.Boolean,
+					ResolutionDetail: openfeature.ResolutionDetail{
+						FlagMetadata: tt.flagMetadata,
+					},
+				},
+			}
+
+			event := CreateEvaluationEvent(hookContext, details)
+			gotContextID, ok := event.Attributes[ContextIDKey]
+
+			if ok != tt.wantAttribute {
+				t.Fatalf("context ID attribute presence = %v, want %v", ok, tt.wantAttribute)
+			}
+			if tt.wantAttribute && gotContextID != tt.wantContextID {
+				t.Errorf("context ID = %v, want %q", gotContextID, tt.wantContextID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #563.

`feature_flag.context.id` was being added as an empty string when there was no targeting key.

This uses `contextId` from flag metadata first, falls back to the targeting key, and leaves the attribute out when neither is available.

Added tests for these cases.