### PR TITLE
fix(multi): stop unchecked type assertions panicking out of flag evaluation

### DIFF
--- a/openfeature/multi/comparison_strategy.go
+++ b/openfeature/multi/comparison_strategy.go
@@ -89,8 +89,8 @@ func evaluateComparison[T FlagTypes](providers []NamedProvider, fallbackProvider
 			case int8, int16, int32, int64, int, uint8, uint16, uint32, uint64, uint, uintptr, float32, float64, string, bool:
 				break
 			default:
-				t := reflect.TypeOf(defaultValue)
-				if !t.Comparable() {
+				// a nil default has no type to compare, see #546
+				if t := reflect.TypeOf(defaultValue); t == nil || !t.Comparable() {
 					// Impossible to evaluate strategy with expected result type
 					defaultResult := BuildDefaultResult(StrategyComparison, defaultValue, ErrAggregationNotAllowed)
 					defaultResult.FlagMetadata[MetadataFallbackUsed] = false

--- a/openfeature/multi/comparison_strategy_test.go
+++ b/openfeature/multi/comparison_strategy_test.go
@@ -739,4 +739,22 @@ func Test_ComparisonStrategy_ObjectEvaluation(t *testing.T) {
 		assert.Equal(t, "none", result.FlagMetadata[MetadataSuccessfulProviderName])
 		assert.False(t, result.FlagMetadata[MetadataFallbackUsed].(bool))
 	})
+
+	t.Run("nil default value returns the default instead of panicking", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		fallback := of.NewMockFeatureProvider(ctrl)
+		provider := of.NewMockFeatureProvider(ctrl)
+		strategy := newComparisonStrategy([]NamedProvider{
+			&namedProvider{
+				name:            "test-provider1",
+				FeatureProvider: provider,
+			},
+		}, fallback, nil)
+
+		result := strategy(t.Context(), testFlag, nil, of.FlattenedContext{})
+		assert.Nil(t, result.Value)
+		assert.Equal(t, of.ErrorReason, result.Reason)
+		assert.Equal(t, of.NewGeneralResolutionError(ErrAggregationNotAllowed.Error()), result.ResolutionError)
+		assert.False(t, result.FlagMetadata[MetadataFallbackUsed].(bool))
+	})
 }

--- a/openfeature/multi/multiprovider.go
+++ b/openfeature/multi/multiprovider.go
@@ -309,7 +309,7 @@ func (p *Provider) Hooks() []of.Hook {
 func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, flatCtx of.FlattenedContext) of.BoolResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
 	return of.BoolResolutionDetail{
-		Value:                    res.Value.(bool),
+		Value:                    valueOrDefault(res.Value, defaultValue),
 		ProviderResolutionDetail: res.ProviderResolutionDetail,
 	}
 }
@@ -318,7 +318,7 @@ func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultVa
 func (p *Provider) StringEvaluation(ctx context.Context, flag string, defaultValue string, flatCtx of.FlattenedContext) of.StringResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
 	return of.StringResolutionDetail{
-		Value:                    res.Value.(string),
+		Value:                    valueOrDefault(res.Value, defaultValue),
 		ProviderResolutionDetail: res.ProviderResolutionDetail,
 	}
 }
@@ -327,7 +327,7 @@ func (p *Provider) StringEvaluation(ctx context.Context, flag string, defaultVal
 func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, flatCtx of.FlattenedContext) of.FloatResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
 	return of.FloatResolutionDetail{
-		Value:                    res.Value.(float64),
+		Value:                    valueOrDefault(res.Value, defaultValue),
 		ProviderResolutionDetail: res.ProviderResolutionDetail,
 	}
 }
@@ -336,7 +336,7 @@ func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValu
 func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, flatCtx of.FlattenedContext) of.IntResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
 	return of.IntResolutionDetail{
-		Value:                    res.Value.(int64),
+		Value:                    valueOrDefault(res.Value, defaultValue),
 		ProviderResolutionDetail: res.ProviderResolutionDetail,
 	}
 }

--- a/openfeature/multi/multiprovider.go
+++ b/openfeature/multi/multiprovider.go
@@ -308,37 +308,25 @@ func (p *Provider) Hooks() []of.Hook {
 // BooleanEvaluation evaluates the flag and returns a [of.BoolResolutionDetail].
 func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultValue bool, flatCtx of.FlattenedContext) of.BoolResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
-	return of.BoolResolutionDetail{
-		Value:                    valueOrDefault(res.Value, defaultValue),
-		ProviderResolutionDetail: res.ProviderResolutionDetail,
-	}
+	return resolveTyped(res.Value, res.ProviderResolutionDetail, defaultValue)
 }
 
 // StringEvaluation evaluates the flag and returns a [of.StringResolutionDetail].
 func (p *Provider) StringEvaluation(ctx context.Context, flag string, defaultValue string, flatCtx of.FlattenedContext) of.StringResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
-	return of.StringResolutionDetail{
-		Value:                    valueOrDefault(res.Value, defaultValue),
-		ProviderResolutionDetail: res.ProviderResolutionDetail,
-	}
+	return resolveTyped(res.Value, res.ProviderResolutionDetail, defaultValue)
 }
 
 // FloatEvaluation evaluates the flag and returns a [of.FloatResolutionDetail].
 func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, flatCtx of.FlattenedContext) of.FloatResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
-	return of.FloatResolutionDetail{
-		Value:                    valueOrDefault(res.Value, defaultValue),
-		ProviderResolutionDetail: res.ProviderResolutionDetail,
-	}
+	return resolveTyped(res.Value, res.ProviderResolutionDetail, defaultValue)
 }
 
 // IntEvaluation evaluates the flag and returns an [of.IntResolutionDetail].
 func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue int64, flatCtx of.FlattenedContext) of.IntResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
-	return of.IntResolutionDetail{
-		Value:                    valueOrDefault(res.Value, defaultValue),
-		ProviderResolutionDetail: res.ProviderResolutionDetail,
-	}
+	return resolveTyped(res.Value, res.ProviderResolutionDetail, defaultValue)
 }
 
 // ObjectEvaluation evaluates the flag and returns an [of.InterfaceResolutionDetail]. For the purposes of evaluation
@@ -347,10 +335,7 @@ func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue 
 // is not a comparable type unless the [WithCustomComparator] [Option] is configured.
 func (p *Provider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, flatCtx of.FlattenedContext) of.InterfaceResolutionDetail {
 	res := p.strategyFunc(ctx, flag, defaultValue, flatCtx)
-	return of.InterfaceResolutionDetail{
-		Value:                    res.Value,
-		ProviderResolutionDetail: res.ProviderResolutionDetail,
-	}
+	return resolveTyped(res.Value, res.ProviderResolutionDetail, defaultValue)
 }
 
 // Init will run the initialize method for all internal [of.FeatureProvider] instances and aggregate any errors.

--- a/openfeature/multi/multiprovider_test.go
+++ b/openfeature/multi/multiprovider_test.go
@@ -78,6 +78,44 @@ func TestMultiProvider_NewMultiProvider(t *testing.T) {
 	})
 }
 
+// A custom strategy may return a zero-value result, and the typed accessors asserted on it
+// without checking, so an unset Value took the calling process down.
+func TestMultiProvider_TypedAccessorsWithUnsetStrategyValue(t *testing.T) {
+	mp, err := NewProvider(StrategyCustom, WithCustomStrategy(func(providers []NamedProvider) StrategyFn[FlagTypes] {
+		return func(ctx context.Context, flag string, defaultValue FlagTypes, evalCtx of.FlattenedContext) of.GenericResolutionDetail[FlagTypes] {
+			return of.GenericResolutionDetail[FlagTypes]{}
+		}
+	}),
+		WithProvider("provider1", imp.NewInMemoryProvider(map[string]imp.InMemoryFlag{})),
+	)
+	require.NoError(t, err)
+
+	assert.True(t, mp.BooleanEvaluation(t.Context(), "flag", true, of.FlattenedContext{}).Value)
+	assert.Equal(t, "fallback", mp.StringEvaluation(t.Context(), "flag", "fallback", of.FlattenedContext{}).Value)
+	assert.InDelta(t, 1.5, mp.FloatEvaluation(t.Context(), "flag", 1.5, of.FlattenedContext{}).Value, 0.001)
+	assert.Equal(t, int64(7), mp.IntEvaluation(t.Context(), "flag", 7, of.FlattenedContext{}).Value)
+}
+
+// An inner provider may resolve an object flag to a nil value, and nil has no type to assert
+// against, so the strategy's object branch panicked rather than resolving.
+func TestMultiProvider_ObjectEvaluationWithNilProviderValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := of.NewMockFeatureProvider(ctrl)
+	provider.EXPECT().Metadata().Return(of.Metadata{Name: "nil-object"}).AnyTimes()
+	provider.EXPECT().Hooks().Return(nil).AnyTimes()
+	provider.EXPECT().ObjectEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(of.InterfaceResolutionDetail{
+			ProviderResolutionDetail: of.ProviderResolutionDetail{Reason: of.StaticReason},
+		})
+
+	mp, err := NewProvider(StrategyFirstMatch, WithProvider("nil-object", provider))
+	require.NoError(t, err)
+
+	defaultValue := map[string]any{"enabled": true}
+	res := mp.ObjectEvaluation(t.Context(), "flag", defaultValue, of.FlattenedContext{})
+	assert.Equal(t, defaultValue, res.Value)
+}
+
 func TestMultiProvider_MetaData(t *testing.T) {
 	t.Run("two providers", func(t *testing.T) {
 		testProvider1 := imp.NewInMemoryProvider(map[string]imp.InMemoryFlag{})

--- a/openfeature/multi/multiprovider_test.go
+++ b/openfeature/multi/multiprovider_test.go
@@ -92,7 +92,7 @@ func TestMultiProvider_TypedAccessorsWithUnsetStrategyValue(t *testing.T) {
 
 	assert.True(t, mp.BooleanEvaluation(t.Context(), "flag", true, of.FlattenedContext{}).Value)
 	assert.Equal(t, "fallback", mp.StringEvaluation(t.Context(), "flag", "fallback", of.FlattenedContext{}).Value)
-	assert.InDelta(t, 1.5, mp.FloatEvaluation(t.Context(), "flag", 1.5, of.FlattenedContext{}).Value, 0.001)
+	assert.Equal(t, 1.5, mp.FloatEvaluation(t.Context(), "flag", 1.5, of.FlattenedContext{}).Value)
 	assert.Equal(t, int64(7), mp.IntEvaluation(t.Context(), "flag", 7, of.FlattenedContext{}).Value)
 }
 
@@ -114,6 +114,45 @@ func TestMultiProvider_ObjectEvaluationWithNilProviderValue(t *testing.T) {
 	defaultValue := map[string]any{"enabled": true}
 	res := mp.ObjectEvaluation(t.Context(), "flag", defaultValue, of.FlattenedContext{})
 	assert.Equal(t, defaultValue, res.Value)
+}
+
+// The object accessor asserted nothing at all, so a strategy that resolved no value
+// returned nil to the caller in place of their default.
+func TestMultiProvider_ObjectEvaluationWithUnsetStrategyValue(t *testing.T) {
+	mp, err := NewProvider(StrategyCustom, WithCustomStrategy(func(providers []NamedProvider) StrategyFn[FlagTypes] {
+		return func(ctx context.Context, flag string, defaultValue FlagTypes, evalCtx of.FlattenedContext) of.GenericResolutionDetail[FlagTypes] {
+			return of.GenericResolutionDetail[FlagTypes]{}
+		}
+	}),
+		WithProvider("provider1", imp.NewInMemoryProvider(map[string]imp.InMemoryFlag{})),
+	)
+	require.NoError(t, err)
+
+	defaultValue := map[string]any{"enabled": true}
+	assert.Equal(t, defaultValue, mp.ObjectEvaluation(t.Context(), "flag", defaultValue, of.FlattenedContext{}).Value)
+}
+
+// A strategy that resolves the wrong type is a bug in the strategy, and reporting it as a
+// successful resolution of the default leaves the caller nothing to diagnose it with.
+func TestMultiProvider_TypedAccessorsWithWrongTypedStrategyValue(t *testing.T) {
+	mp, err := NewProvider(StrategyCustom, WithCustomStrategy(func(providers []NamedProvider) StrategyFn[FlagTypes] {
+		return func(ctx context.Context, flag string, defaultValue FlagTypes, evalCtx of.FlattenedContext) of.GenericResolutionDetail[FlagTypes] {
+			return of.GenericResolutionDetail[FlagTypes]{
+				Value:                    "not-a-bool",
+				ProviderResolutionDetail: of.ProviderResolutionDetail{Reason: of.StaticReason},
+			}
+		}
+	}),
+		WithProvider("provider1", imp.NewInMemoryProvider(map[string]imp.InMemoryFlag{})),
+	)
+	require.NoError(t, err)
+
+	res := mp.BooleanEvaluation(t.Context(), "flag", true, of.FlattenedContext{})
+	assert.True(t, res.Value)
+	assert.Equal(t, of.ErrorReason, res.Reason)
+	assert.Equal(t,
+		of.NewTypeMismatchResolutionError("strategy resolved string, expected bool").Error(),
+		res.ResolutionError.Error())
 }
 
 func TestMultiProvider_MetaData(t *testing.T) {

--- a/openfeature/multi/strategies.go
+++ b/openfeature/multi/strategies.go
@@ -109,6 +109,16 @@ func mergeFlagMeta(tags ...of.FlagMetadata) of.FlagMetadata {
 	}
 }
 
+// valueOrDefault returns value when it holds the expected type, and the caller's default
+// otherwise. A strategy may leave Value unset, and a nil has no type to assert, see #546
+func valueOrDefault[T any](value any, defaultValue T) T {
+	if v, ok := value.(T); ok {
+		return v
+	}
+
+	return defaultValue
+}
+
 // BuildDefaultResult should be called when a [StrategyFn] is in a failure state and needs to return a default value.
 // This method will build a resolution detail with the internal provided error set. This method is exported for those
 // writing their own custom [StrategyFn].
@@ -158,7 +168,7 @@ func Evaluate[T FlagTypes](ctx context.Context, provider NamedProvider, flag str
 	default:
 		res := provider.ObjectEvaluation(ctx, flag, defaultVal, flatCtx)
 		resolution.ProviderResolutionDetail = res.ProviderResolutionDetail
-		resolution.Value = res.Value.(T)
+		resolution.Value = valueOrDefault(res.Value, defaultVal)
 	}
 
 	if resolution.FlagMetadata == nil {

--- a/openfeature/multi/strategies.go
+++ b/openfeature/multi/strategies.go
@@ -2,6 +2,7 @@ package multi
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"regexp"
 	"strings"
@@ -109,14 +110,21 @@ func mergeFlagMeta(tags ...of.FlagMetadata) of.FlagMetadata {
 	}
 }
 
-// valueOrDefault returns value when it holds the expected type, and the caller's default
-// otherwise. A strategy may leave Value unset, and a nil has no type to assert, see #546
-func valueOrDefault[T any](value any, defaultValue T) T {
+// resolveTyped builds the resolution for value, falling back to the caller's default.
+// A nil value means the strategy resolved nothing, so the default stands on its own.
+// A value of the wrong type is a strategy bug and is reported as a type mismatch rather
+// than returned under the provider's success reason.
+func resolveTyped[T any](value any, detail of.ProviderResolutionDetail, defaultValue T) of.GenericResolutionDetail[T] {
+	typed := of.GenericResolutionDetail[T]{Value: defaultValue, ProviderResolutionDetail: detail}
 	if v, ok := value.(T); ok {
-		return v
+		typed.Value = v
+	} else if value != nil {
+		typed.ResolutionError = of.NewTypeMismatchResolutionError(
+			fmt.Sprintf("strategy resolved %T, expected %T", value, defaultValue))
+		typed.Reason = of.ErrorReason
 	}
 
-	return defaultValue
+	return typed
 }
 
 // BuildDefaultResult should be called when a [StrategyFn] is in a failure state and needs to return a default value.
@@ -167,8 +175,7 @@ func Evaluate[T FlagTypes](ctx context.Context, provider NamedProvider, flag str
 		resolution.Value = any(res.Value).(T)
 	default:
 		res := provider.ObjectEvaluation(ctx, flag, defaultVal, flatCtx)
-		resolution.ProviderResolutionDetail = res.ProviderResolutionDetail
-		resolution.Value = valueOrDefault(res.Value, defaultVal)
+		resolution = resolveTyped(res.Value, res.ProviderResolutionDetail, defaultVal)
 	}
 
 	if resolution.FlagMetadata == nil {


### PR DESCRIPTION
## This PR

- guards `reflect.TypeOf(defaultValue)` against a nil default in `evaluateComparison`, so a nil object default resolves instead of panicking
- returns the caller's default when a strategy leaves `Value` unset, at the four typed accessors on `Provider` and in the object branch of `Evaluate`
- does the same for `Provider.ObjectEvaluation`, which asserted nothing and passed the nil straight through to the client
- reports a wrong-typed strategy value as `TYPE_MISMATCH` with an `ERROR` reason, rather than returning the default under a success reason
- adds coverage for each path

### Related Issues

Fixes #546

### Notes

All three panics in the issue reproduce at `9853ca0`, and the last two share a root cause, an unchecked type assertion on a value the strategy may leave nil, so they are fixed by one unexported helper rather than three separate guards:

| # | Panic | Site |
|---|---|---|
| 1 | `reflect.TypeOf(nil).Comparable()` nil deref | `comparison_strategy.go:93` |
| 2 | `interface conversion: multi.FlagTypes is nil, not bool` | `multiprovider.go:312` |
| 3 | `interface conversion: interface is nil, not multi.FlagTypes` | `strategies.go:161` |

Claim 1 is broader than the issue states. The nil default escapes the client too, not just the provider, which makes it a 1.4.10 violation rather than a `multi`-internal panic. Reproduced through `client.ObjectValue`.

The open question about `TYPE_MISMATCH` is settled: @erka  and @sahidvelji both preferred it, so the fallback no longer hides behind the provider's success reason. `resolveTyped` splits the two cases. A nil value means the strategy resolved nothing, so the caller's default stands on its own. A value of the wrong type is a bug in the strategy, so it comes back as the default plus `TYPE_MISMATCH` with an `ERROR` reason. Through the client that reads:

    provider -> Value=true Reason="ERROR" Err="TYPE_MISMATCH: strategy resolved string, expected bool"
    client   -> Value=true Reason="ERROR" ErrorCode="TYPE_MISMATCH"

Review also turned up a fourth site the issue does not list. `Provider.ObjectEvaluation` asserted nothing at all, so an unset strategy value reached `Client.ObjectValue` as nil with no error and no reason to go with it:

    mp.ObjectEvaluation       -> Value=<nil>  Reason=""
    client.ObjectValue        -> value=<nil>  err=<nil>
    client.ObjectValueDetails -> value=<nil>  reason=""  code=""  err=<nil>

`BooleanEvaluation` on the same strategy returns the default, so this is the same 1.4.10 gap as the other claims, only silent. It goes through `resolveTyped` with the rest.

Each new test was checked against a reverted fix, so they fail for the right reason: the panic cases die with the message in the table above, and the two added in review return `nil` and a `STATIC` reason respectively.

### How to test

```go
// claim 1 — a nil object default under StrategyComparison
mp, _ := multi.NewProvider(multi.StrategyComparison,
      multi.WithProvider("a", someProvider), multi.WithProvider("b", otherProvider))
mp.InitWithContext(context.Background(), of.EvaluationContext{})
mp.ObjectEvaluation(context.Background(), "flag", nil, of.FlattenedContext{}) // panics on main

// the same through the client, which is the 1.4.10 case
api := isolated.NewAPI()
api.SetProviderAndWait(context.Background(), mp)
api.NewClient().ObjectValue(context.Background(), "flag", nil, of.EvaluationContext{}) // panics on main

// claim 2 — a custom strategy that gives up
strategy := func(providers []multi.NamedProvider) multi.StrategyFn[multi.FlagTypes] {
      return func(context.Context, string, multi.FlagTypes, of.FlattenedContext) of.GenericResolutionDetail[multi.FlagTypes] {
              return of.GenericResolutionDetail[multi.FlagTypes]{}
      }
}
mp2, _ := multi.NewProvider(multi.StrategyCustom,
      multi.WithCustomStrategy(strategy), multi.WithProvider("p", someProvider))
mp2.BooleanEvaluation(context.Background(), "flag", true, of.FlattenedContext{}) // panics on main

// claim 3 — an inner provider resolving an object flag to nil
mp3, _ := multi.NewProvider(multi.StrategyFirstMatch, multi.WithProvider("nil-object", nilObjectProvider{}))
mp3.ObjectEvaluation(context.Background(), "flag", map[string]any{"d": true}, of.FlattenedContext{}) // panics on main

// the fourth site — the same giving-up strategy, reaching the object accessor
mp2.ObjectEvaluation(context.Background(), "flag", map[string]any{"kept": true}, of.FlattenedContext{})
// on main: Value=<nil>, no error, no reason. client.ObjectValue returns nil too.

// a strategy that resolves the wrong type
wrongType := func(providers []multi.NamedProvider) multi.StrategyFn[multi.FlagTypes] {
      return func(context.Context, string, multi.FlagTypes, of.FlattenedContext) of.GenericResolutionDetail[multi.FlagTypes] {
              return of.GenericResolutionDetail[multi.FlagTypes]{
                      Value:                    "not-a-bool",
                      ProviderResolutionDetail: of.ProviderResolutionDetail{Reason: of.StaticReason},
              }
      }
}
mp4, _ := multi.NewProvider(multi.StrategyCustom,
      multi.WithCustomStrategy(wrongType), multi.WithProvider("p", someProvider))
mp4.BooleanEvaluation(context.Background(), "flag", true, of.FlattenedContext{})
// on main: Value=true with Reason=STATIC and no error. Now: Reason=ERROR, TYPE_MISMATCH.
```