### PR TITLE
fix(multi): buffer the comparison strategy's not-found channel

### DIFF
--- a/openfeature/multi/comparison_strategy.go
+++ b/openfeature/multi/comparison_strategy.go
@@ -115,7 +115,8 @@ func evaluateComparison[T FlagTypes](providers []NamedProvider, fallbackProvider
 		}
 
 		resultChan := make(chan *namedResult, len(providers))
-		notFoundChan := make(chan any)
+		// buffered so a sender never outlives the listener loop, see #547
+		notFoundChan := make(chan any, len(providers))
 		errGrp, grpCtx := errgroup.WithContext(ctx)
 		for _, provider := range providers {
 			closedProvider := provider

--- a/openfeature/multi/comparison_strategy_test.go
+++ b/openfeature/multi/comparison_strategy_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	of "github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 )
 
@@ -757,4 +759,58 @@ func Test_ComparisonStrategy_ObjectEvaluation(t *testing.T) {
 		assert.Equal(t, of.NewGeneralResolutionError(ErrAggregationNotAllowed.Error()), result.ResolutionError)
 		assert.False(t, result.FlagMetadata[MetadataFallbackUsed].(bool))
 	})
+}
+
+// configureDelayedNotFoundProvider reports FLAG_NOT_FOUND only after delay, so the
+// provider is still mid-evaluation when another one cancels the group.
+func configureDelayedNotFoundProvider(provider *of.MockFeatureProvider, delay time.Duration) {
+	provider.EXPECT().Metadata().Return(of.Metadata{Name: "mock provider"}).MaxTimes(1)
+	provider.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(c context.Context, flag string, defaultVal bool, evalCtx of.FlattenedContext) of.BoolResolutionDetail {
+		time.Sleep(delay)
+		return of.BoolResolutionDetail{
+			Value: defaultVal,
+			ProviderResolutionDetail: of.ProviderResolutionDetail{
+				ResolutionError: of.NewFlagNotFoundResolutionError("not found"),
+				Reason:          of.DefaultReason,
+				FlagMetadata:    make(of.FlagMetadata),
+			},
+		}
+	}).MaxTimes(1)
+}
+
+func Test_ComparisonStrategy_NotFoundSendersDoNotOutliveEvaluation(t *testing.T) {
+	// the multi package has no goleak TestMain, so this test verifies its own goroutines
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctrl := gomock.NewController(t)
+	fallback := of.NewMockFeatureProvider(ctrl)
+
+	// the failing provider cancels the group while the not-found providers are still
+	// sleeping, so both reach the send after the listener loop has already returned
+	failing := of.NewMockFeatureProvider(ctrl)
+	configureComparisonProvider(failing, false, true, TestErrorError, false)
+	slowNotFound1 := of.NewMockFeatureProvider(ctrl)
+	configureDelayedNotFoundProvider(slowNotFound1, 50*time.Millisecond)
+	slowNotFound2 := of.NewMockFeatureProvider(ctrl)
+	configureDelayedNotFoundProvider(slowNotFound2, 50*time.Millisecond)
+
+	strategy := newComparisonStrategy([]NamedProvider{
+		&namedProvider{
+			name:            "failing-provider",
+			FeatureProvider: failing,
+		},
+		&namedProvider{
+			name:            "slow-not-found-provider1",
+			FeatureProvider: slowNotFound1,
+		},
+		&namedProvider{
+			name:            "slow-not-found-provider2",
+			FeatureProvider: slowNotFound2,
+		},
+	}, fallback, nil)
+
+	result := strategy(t.Context(), testFlag, false, of.FlattenedContext{})
+	assert.Equal(t, false, result.Value)
+	assert.Equal(t, of.ErrorReason, result.Reason)
+	assert.True(t, result.FlagMetadata[MetadataIsDefaultValue].(bool))
 }

--- a/openfeature/multi/comparison_strategy_test.go
+++ b/openfeature/multi/comparison_strategy_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	of "github.com/open-feature/go-sdk/openfeature"
 	"github.com/stretchr/testify/assert"
@@ -761,12 +760,10 @@ func Test_ComparisonStrategy_ObjectEvaluation(t *testing.T) {
 	})
 }
 
-// configureDelayedNotFoundProvider reports FLAG_NOT_FOUND only after delay, so the
-// provider is still mid-evaluation when another one cancels the group.
-func configureDelayedNotFoundProvider(provider *of.MockFeatureProvider, delay time.Duration) {
+func configureBlockedNotFoundProvider(provider *of.MockFeatureProvider, release <-chan struct{}) {
 	provider.EXPECT().Metadata().Return(of.Metadata{Name: "mock provider"}).MaxTimes(1)
 	provider.EXPECT().BooleanEvaluation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(c context.Context, flag string, defaultVal bool, evalCtx of.FlattenedContext) of.BoolResolutionDetail {
-		time.Sleep(delay)
+		<-release
 		return of.BoolResolutionDetail{
 			Value: defaultVal,
 			ProviderResolutionDetail: of.ProviderResolutionDetail{
@@ -784,15 +781,14 @@ func Test_ComparisonStrategy_NotFoundSendersDoNotOutliveEvaluation(t *testing.T)
 
 	ctrl := gomock.NewController(t)
 	fallback := of.NewMockFeatureProvider(ctrl)
+	release := make(chan struct{})
 
-	// the failing provider cancels the group while the not-found providers are still
-	// sleeping, so both reach the send after the listener loop has already returned
 	failing := of.NewMockFeatureProvider(ctrl)
 	configureComparisonProvider(failing, false, true, TestErrorError, false)
-	slowNotFound1 := of.NewMockFeatureProvider(ctrl)
-	configureDelayedNotFoundProvider(slowNotFound1, 50*time.Millisecond)
-	slowNotFound2 := of.NewMockFeatureProvider(ctrl)
-	configureDelayedNotFoundProvider(slowNotFound2, 50*time.Millisecond)
+	blockedNotFound1 := of.NewMockFeatureProvider(ctrl)
+	configureBlockedNotFoundProvider(blockedNotFound1, release)
+	blockedNotFound2 := of.NewMockFeatureProvider(ctrl)
+	configureBlockedNotFoundProvider(blockedNotFound2, release)
 
 	strategy := newComparisonStrategy([]NamedProvider{
 		&namedProvider{
@@ -800,16 +796,24 @@ func Test_ComparisonStrategy_NotFoundSendersDoNotOutliveEvaluation(t *testing.T)
 			FeatureProvider: failing,
 		},
 		&namedProvider{
-			name:            "slow-not-found-provider1",
-			FeatureProvider: slowNotFound1,
+			name:            "blocked-not-found-provider1",
+			FeatureProvider: blockedNotFound1,
 		},
 		&namedProvider{
-			name:            "slow-not-found-provider2",
-			FeatureProvider: slowNotFound2,
+			name:            "blocked-not-found-provider2",
+			FeatureProvider: blockedNotFound2,
 		},
 	}, fallback, nil)
 
-	result := strategy(t.Context(), testFlag, false, of.FlattenedContext{})
+	var result of.GenericResolutionDetail[FlagTypes]
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		result = strategy(t.Context(), testFlag, false, of.FlattenedContext{})
+	}()
+	<-done
+	close(release)
+
 	assert.Equal(t, false, result.Value)
 	assert.Equal(t, of.ErrorReason, result.Reason)
 	assert.True(t, result.FlagMetadata[MetadataIsDefaultValue].(bool))


### PR DESCRIPTION
## This PR

- Buffers `notFoundChan` to `len(providers)` in `evaluateComparison`, so a provider goroutine can never block forever on its send.
- Adds `Test_ComparisonStrategy_NotFoundSendersDoNotOutliveEvaluation`, which verifies its own goroutines with `goleak`.

### Related Issues

Fixes #547

### Notes

Reproduced at `86d35ff` through the public API, provider-level and through the client:

```
[provider] goroutines before=2 after 25 evals=52 (delta=50)
[provider] blocked in comparison_strategy.go: 50
[client]   goroutines before=53 after 25 evals=103 (delta=50)
[control all-not-found] delta=0
```

Of the three options in the issue I took the first one. The other two are not equivalent:

`errGrp.Wait()` before returning would make the evaluation wait on the slowest not-found provider after another has already failed, which is a latency change on a hot path.

A `select` on `grpCtx.Done()` in the send works today, but only because every return that abandons a sender happens to cancel the group — the loop breaks only when all providers are accounted for, and the sole early return is `<-grpCtx.Done()`. Buffering does not depend on that invariant holding, and it removes the asymmetry that caused the bug: `resultChan` on the line above is already buffered to `len(providers)`, as is every other non-test channel in the package.

It is also worth saying that buffering does not keep the goroutines alive any longer than the select would. The send happens after `Evaluate` has already returned, so a sender that reaches it has no work left. Sampling goroutine counts with the buffer in place, against providers that take 250ms:

```
t+0s     goroutines=+20  in comparison_strategy=20
t+50ms   goroutines=+20  in comparison_strategy=20
t+300ms  goroutines=+0   in comparison_strategy=0
```

The lifetime is bounded by the provider call, which neither option changes.

The test uses `goleak.IgnoreCurrent()` rather than a bare `VerifyNone`. A bare one passes today, but `openfeature/multi` has no `goleak` `TestMain`, so without it this test would start failing for goroutines leaked by some other test in the package rather than for the one it is about.

Out of scope, happy to file separately if you want it: on the `grpCtx.Done()` return, `BuildDefaultResult` builds a GENERAL error and it is then overwritten by `comparisonResolutionError`, so a provider error surfaces as `FLAG_NOT_FOUND` with `Reason=ERROR` and `multiprovider-evaluation-error=context canceled`.

### How to test

`make test` covers it. With the buffer reverted, the new test fails with goleak reporting two goroutines in state `chan send` at `comparison_strategy.go:137`.

`make test`, `make lint` and `make e2e-test` are green, plus `-race -count=5` on the comparison tests.