### PR TITLE
fix(multi): preserve fatal and not-ready provider states

### DIFF
--- a/openfeature/multi/multiprovider.go
+++ b/openfeature/multi/multiprovider.go
@@ -103,7 +103,7 @@ func (n *namedProvider) unwrap() of.FeatureProvider {
 
 var (
 	stateValues      map[of.State]int
-	stateTable       [3]of.State
+	stateTable       [5]of.State
 	eventTypeToState map[of.EventType]of.State
 
 	// Compile-time interface compliance checks
@@ -118,15 +118,19 @@ var (
 func init() {
 	// used for mapping provider event types & provider states to comparable values for evaluation
 	stateValues = map[of.State]int{
-		of.ReadyState: 0,
-		of.StaleState: 1,
-		of.ErrorState: 2,
+		of.ReadyState:    0,
+		of.StaleState:    1,
+		of.ErrorState:    2,
+		of.NotReadyState: 3,
+		of.FatalState:    4,
 	}
 	// used for mapping
-	stateTable = [3]of.State{
-		of.ReadyState, // 0
-		of.StaleState, // 1
-		of.ErrorState, // 2
+	stateTable = [5]of.State{
+		of.ReadyState,
+		of.StaleState,
+		of.ErrorState,
+		of.NotReadyState,
+		of.FatalState,
 	}
 	eventTypeToState = map[of.EventType]of.State{
 		of.ProviderReady: of.ReadyState,
@@ -507,8 +511,16 @@ func (p *Provider) updateProviderStateFromEvent(e namedEvent) bool {
 	p.providerStatusLock.Lock()
 	previousState := p.providerStatus[e.providerName]
 	p.providerStatusLock.Unlock()
-	logProviderState(p.logger, e, previousState)
-	return p.updateProviderState(e.providerName, eventTypeToState[e.EventType])
+	state := stateFromEvent(e)
+	logProviderState(p.logger, e, state, previousState)
+	return p.updateProviderState(e.providerName, state)
+}
+
+func stateFromEvent(e namedEvent) of.State {
+	if e.EventType == of.ProviderError && e.ErrorCode == of.ProviderFatalCode {
+		return of.FatalState
+	}
+	return eventTypeToState[e.EventType]
 }
 
 // evaluateState Determines the overall state of the provider using the weights specified in Appendix A of the
@@ -524,8 +536,8 @@ func (p *Provider) evaluateState() of.State {
 	return stateTable[maxState]
 }
 
-func logProviderState(l *slog.Logger, e namedEvent, previousState of.State) {
-	switch eventTypeToState[e.EventType] {
+func logProviderState(l *slog.Logger, e namedEvent, state, previousState of.State) {
+	switch state {
 	case of.ReadyState:
 		if previousState != of.NotReadyState {
 			l.LogAttrs(context.Background(), slog.LevelInfo, "provider has returned to ready state",
@@ -538,6 +550,9 @@ func logProviderState(l *slog.Logger, e namedEvent, previousState of.State) {
 			slog.String(MetadataProviderName, e.providerName), slog.String("event-message", e.Message))
 	case of.ErrorState:
 		l.LogAttrs(context.Background(), slog.LevelError, "provider is in an error state",
+			slog.String(MetadataProviderName, e.providerName), slog.String("event-message", e.Message))
+	case of.FatalState:
+		l.LogAttrs(context.Background(), slog.LevelError, "provider is in a fatal state",
 			slog.String(MetadataProviderName, e.providerName), slog.String("event-message", e.Message))
 	}
 }

--- a/openfeature/multi/multiprovider_test.go
+++ b/openfeature/multi/multiprovider_test.go
@@ -252,6 +252,39 @@ func TestMultiProvider_Init(t *testing.T) {
 	assert.Equal(t, of.ReadyState, mp.Status())
 }
 
+func TestMultiProvider_InitReportsNotReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := of.NewMockFeatureProvider(ctrl)
+	provider.EXPECT().Metadata().Return(of.Metadata{Name: "MockProvider"})
+	provider.EXPECT().Hooks().Return([]of.Hook{}).MinTimes(1)
+	stateHandler := of.NewMockStateHandler(ctrl)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	stateHandler.EXPECT().Init(gomock.Any()).DoAndReturn(func(of.EvaluationContext) error {
+		close(started)
+		<-release
+		return nil
+	})
+	stateHandler.EXPECT().Shutdown().MaxTimes(1)
+	wrapped := struct {
+		of.FeatureProvider
+		of.StateHandler
+	}{provider, stateHandler}
+
+	mp, err := NewProvider(StrategyFirstMatch, WithProvider("provider", wrapped))
+	require.NoError(t, err)
+	t.Cleanup(mp.Shutdown)
+
+	initDone := make(chan error, 1)
+	go func() {
+		initDone <- mp.InitWithContext(t.Context(), of.EvaluationContext{})
+	}()
+	<-started
+	assert.Equal(t, of.NotReadyState, mp.Status())
+	close(release)
+	require.NoError(t, <-initDone)
+}
+
 func TestMultiProvider_InitErrorWithProvider(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	errProvider := of.NewMockFeatureProvider(ctrl)
@@ -446,6 +479,27 @@ func TestMultiProvider_StateUpdateWithSameTypeProviders(t *testing.T) {
 	if numProviders != 2 {
 		t.Errorf("Expected 2 providers in status map, got %d", numProviders)
 	}
+}
+
+func TestMultiProvider_FatalEventUpdatesStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := newMockProviderWithEvents(ctrl, "fatal-provider")
+	mp, err := NewProvider(StrategyFirstMatch, WithProvider("fatal-provider", provider))
+	require.NoError(t, err)
+	t.Cleanup(mp.Shutdown)
+	require.NoError(t, mp.Init(of.EvaluationContext{}))
+
+	provider.eventChannel <- of.Event{
+		EventType: of.ProviderError,
+		ProviderEventDetails: of.ProviderEventDetails{
+			ErrorCode:     of.ProviderFatalCode,
+			EventMetadata: map[string]any{},
+		},
+	}
+
+	require.Eventually(t, func() bool {
+		return mp.Status() == of.FatalState
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestMultiProvider_ConfigurationChangedEventForwarding(t *testing.T) {


### PR DESCRIPTION
## This PR

  - Preserve `NOT_READY` when any inner provider is still initializing.
  - Map `PROVIDER_FATAL` events to `FATAL` instead of `ERROR`.
  - Apply the complete provider-state precedence order.
  - Add regression tests for initialization and fatal provider events.

  ### Related Issues

  Fixes #544

  ### Notes

  The previous state table only represented `READY`, `STALE`, and `ERROR`, causing `NOT_READY` and `FATAL` states to be lost during
  aggregation.

  This change preserves the full precedence order:

  `READY < STALE < ERROR < NOT_READY < FATAL`

  Only `PROVIDER_ERROR` events carrying the `PROVIDER_FATAL` error code map to `FATAL`; other provider errors retain their existing behavior.

  ### How to test

  - `make test`
  - `make lint`
  - `make e2e-test`

  All checks pass locally.